### PR TITLE
Fix conditional hook usage during initialization

### DIFF
--- a/alimentos.json
+++ b/alimentos.json
@@ -1,0 +1,111 @@
+{
+  "meals": [
+    {
+      "id": "whey_agua",
+      "name": "Whey Protein Isolado (Água)",
+      "block": "250",
+      "tags": ["High Protein", "Low Carb", "Quick"],
+      "ingredients": [
+        {"name": "Whey Protein (1 Scoop)", "protein": 25, "carbs": 5, "fats": 4, "baseKcal": 155}
+      ]
+    },
+    {
+      "id": "shake_caseina",
+      "name": "Shake de Caseína (Pré-Cama)",
+      "block": "250",
+      "tags": ["High Protein", "Low Carb"],
+      "ingredients": [
+        {"name": "Caseína/Whey", "protein": 30, "carbs": 4, "fats": 3, "baseKcal": 170}
+      ]
+    },
+    {
+      "id": "ovo_cozido",
+      "name": "2 Ovos Cozidos",
+      "block": "250",
+      "tags": ["High Protein", "Low Carb", "High Fat"],
+      "ingredients": [
+        {"name": "Ovo Cozido (2 unid.)", "protein": 12, "carbs": 1, "fats": 10, "baseKcal": 140}
+      ]
+    },
+    {
+      "id": "fruta_pasta_amendoim",
+      "name": "Banana + Pasta de Amendoim",
+      "block": "250",
+      "tags": ["High Carb", "Balanced", "Plant-Based"],
+      "ingredients": [
+        {"name": "Banana (média)", "protein": 1, "carbs": 27, "fats": 0, "baseKcal": 105},
+        {"name": "Pasta de Amendoim (1 col. sopa)", "protein": 6, "carbs": 8, "fats": 8, "baseKcal": 145}
+      ]
+    },
+    {
+      "id": "tapioca_ovo_queijo",
+      "name": "Tapioca c/ Ovos e Queijo Minas",
+      "block": "350",
+      "tags": ["Balanced", "Quick", "BR"],
+      "ingredients": [
+        {"name": "Massa de Tapioca (40g)", "protein": 0, "carbs": 35, "fats": 0, "baseKcal": 140},
+        {"name": "2 Ovos + 1 Clara", "protein": 18, "carbs": 0, "fats": 10, "baseKcal": 160},
+        {"name": "Queijo Minas (30g)", "protein": 7, "carbs": 0, "fats": 5, "baseKcal": 60}
+      ]
+    },
+    {
+      "id": "shake_prot_pos",
+      "name": "Shake Pós-Treino Rápido (Completo)",
+      "block": "350",
+      "tags": ["High Protein", "Post-Workout", "High Carb"],
+      "ingredients": [
+        {"name": "Whey Protein (1 Scoop)", "protein": 25, "carbs": 5, "fats": 4, "baseKcal": 155},
+        {"name": "Banana (pequena)", "protein": 1, "carbs": 23, "fats": 0, "baseKcal": 90},
+        {"name": "Aveia (1 col. sopa)", "protein": 4, "carbs": 12, "fats": 2, "baseKcal": 80}
+      ]
+    },
+    {
+      "id": "iogurte_prot_fruta",
+      "name": "Iogurte Proteico + Aveia e Fruta",
+      "block": "350",
+      "tags": ["Balanced", "Quick"],
+      "ingredients": [
+        {"name": "Iogurte Natural/Grego (170g)", "protein": 10, "carbs": 15, "fats": 9, "baseKcal": 180},
+        {"name": "Aveia (15g)", "protein": 3, "carbs": 9, "fats": 1, "baseKcal": 60},
+        {"name": "Banana (média)", "protein": 1, "carbs": 27, "fats": 0, "baseKcal": 105}
+      ]
+    },
+    {
+      "id": "frango_arroz_feijao_padrao",
+      "name": "Frango, Arroz, Feijão (Almoço Padrão)",
+      "block": "500",
+      "tags": ["Balanced", "High Protein", "BR"],
+      "ingredients": [
+        {"name": "Arroz Integral Cozido (100g)", "protein": 2, "carbs": 28, "fats": 1, "baseKcal": 130},
+        {"name": "Feijão Cozido (100g)", "protein": 5, "carbs": 15, "fats": 1, "baseKcal": 100},
+        {"name": "Peito de Frango Grelhado (120g cru)", "protein": 34, "carbs": 0, "fats": 5, "baseKcal": 180},
+        {"name": "Azeite (1 col. chá)", "protein": 0, "carbs": 0, "fats": 5, "baseKcal": 45},
+        {"name": "Salada e Legumes (Livre)", "protein": 2, "carbs": 5, "fats": 0, "baseKcal": 30}
+      ]
+    },
+    {
+      "id": "salmao_quinoa_espinafre",
+      "name": "Salmão Grelhado c/ Quinoa e Espinafre",
+      "block": "500",
+      "tags": ["High Fat Saudável", "Balanced"],
+      "ingredients": [
+        {"name": "Salmão Grelhado (100g)", "protein": 25, "carbs": 0, "fats": 15, "baseKcal": 240},
+        {"name": "Quinoa Cozida (80g)", "protein": 3, "carbs": 14, "fats": 1, "baseKcal": 80},
+        {"name": "Espinafre Refogado (Livre)", "protein": 3, "carbs": 5, "fats": 5, "baseKcal": 70},
+        {"name": "Azeite (1 col. sopa)", "protein": 0, "carbs": 0, "fats": 13, "baseKcal": 117}
+      ]
+    },
+    {
+      "id": "massa_pesto_frango_azeitonas",
+      "name": "Massa Integral c/ Pesto, Frango e Azeitonas",
+      "block": "750",
+      "tags": ["High Carb", "High Protein", "Post-Workout"],
+      "ingredients": [
+        {"name": "Massa Integral Cozida (150g)", "protein": 7, "carbs": 45, "fats": 2, "baseKcal": 230},
+        {"name": "Peito de Frango Picado (150g)", "protein": 40, "carbs": 0, "fats": 6, "baseKcal": 226},
+        {"name": "Molho Pesto (2 col. sopa)", "protein": 5, "carbs": 5, "fats": 20, "baseKcal": 220},
+        {"name": "Tomate Seco e Azeitonas", "protein": 0, "carbs": 5, "fats": 6, "baseKcal": 70}
+      ]
+    }
+  ]
+}

--- a/index.html
+++ b/index.html
@@ -59,9 +59,23 @@ function normalizeAndValidateInput(key, value) {
   return numericValue;
 }
 
+const STATIC_BASE_URL = (() => {
+  try {
+    const { origin, pathname } = window.location;
+    if (pathname.endsWith('/')) return `${origin}${pathname}`;
+    if (pathname.includes('.')) {
+      return `${origin}${pathname.slice(0, pathname.lastIndexOf('/') + 1)}`;
+    }
+    return `${origin}${pathname}/`;
+  } catch (error) {
+    console.warn('Não foi possível determinar a base estática', error);
+    return window.location ? window.location.href : '';
+  }
+})();
+
 const resolveStaticAsset = (relativePath) => {
   try {
-    return new URL(relativePath, window.location.href).toString();
+    return new URL(relativePath, STATIC_BASE_URL).toString();
   } catch (e) {
     console.warn("Falha ao resolver caminho estático", relativePath, e);
     return relativePath;
@@ -275,65 +289,106 @@ function App(){
   const day = allDays[currentDayId] || getInitialDayState(slotKeys);
 
   useEffect(()=>{
-    setIsProfileHydrating(true);
-    let profilesList = [];
-    const storedProfiles = loadState(PROFILES_INDEX_KEY, null);
-    if (Array.isArray(storedProfiles)) {
-      profilesList = storedProfiles.filter(p=>p && p.id && p.name);
-    }
+    let cancelled = false;
+    const fallbackBootstrap = () => {
+      const fallbackId = generateProfileId();
+      const fallbackMeta = { id: fallbackId, name: 'Perfil Principal' };
+      const fallbackDays = { [INITIAL_DAY_ID]: getInitialDayState(INITIAL_SLOT_KEYS) };
+      setProfiles([fallbackMeta]);
+      setSelectedProfileId(fallbackId);
+      setProfile(DEFAULT_PROFILE);
+      setSlotKeys(INITIAL_SLOT_KEYS);
+      setAllDays(fallbackDays);
+      setCurrentDayId(INITIAL_DAY_ID);
+      setProfileNameDraft(fallbackMeta.name);
+      try {
+        saveState(makeProfileKey(fallbackId, 'profile'), DEFAULT_PROFILE);
+        saveState(makeProfileKey(fallbackId, 'slots'), INITIAL_SLOT_KEYS);
+        saveState(makeProfileKey(fallbackId, 'days'), fallbackDays);
+        saveState(makeProfileKey(fallbackId, 'current_day'), INITIAL_DAY_ID);
+        saveState(PROFILES_INDEX_KEY, [fallbackMeta]);
+        saveState(SELECTED_PROFILE_ID_KEY, fallbackId);
+      } catch (err) {
+        console.error('Não foi possível salvar estado padrão', err);
+      }
+    };
 
-    if (profilesList.length === 0) {
-      const singleProfile = loadState(PROFILE_STORAGE_KEY, null);
-      const legacyProfile = singleProfile || loadState(LEGACY_PROFILE_STORAGE_KEY, null);
-      const legacySlots = loadState(LEGACY_SLOTS_STORAGE_KEY, null);
-      const legacyDays = loadState(LEGACY_ALL_DAYS_STORAGE_KEY, null);
-      const legacyCurrentDay = loadState(LEGACY_CURRENT_DAY_ID_STORAGE_KEY, null);
-      const migratedId = generateProfileId();
-      const migratedName = legacyProfile && typeof legacyProfile.name === 'string' && legacyProfile.name.trim().length>0 ? legacyProfile.name.trim() : 'Perfil Principal';
-      const migratedSlots = Array.isArray(legacySlots) && legacySlots.length>0 ? legacySlots : INITIAL_SLOT_KEYS;
-      const migratedDays = normalizeDays(legacyDays, migratedSlots);
-      const migratedCurrentDay = migratedDays[legacyCurrentDay] ? legacyCurrentDay : Object.keys(migratedDays)[0] || INITIAL_DAY_ID;
-      profilesList = [{ id: migratedId, name: migratedName }];
-      const migratedProfile = legacyProfile ? sanitizeProfile({ ...DEFAULT_PROFILE, ...legacyProfile }) : DEFAULT_PROFILE;
-      saveState(makeProfileKey(migratedId, 'profile'), migratedProfile);
-      saveState(makeProfileKey(migratedId, 'slots'), migratedSlots);
-      saveState(makeProfileKey(migratedId, 'days'), migratedDays);
-      saveState(makeProfileKey(migratedId, 'current_day'), migratedCurrentDay);
-      removeState(PROFILE_STORAGE_KEY);
-      removeState(LEGACY_PROFILE_STORAGE_KEY);
-    }
+    const bootstrap = () => {
+      setIsProfileHydrating(true);
+      try {
+        let profilesList = [];
+        const storedProfiles = loadState(PROFILES_INDEX_KEY, null);
+        if (Array.isArray(storedProfiles)) {
+          profilesList = storedProfiles.filter(p=>p && p.id && p.name);
+        }
 
-    if (profilesList.length === 0) {
-      const defaultId = generateProfileId();
-      profilesList = [{ id: defaultId, name: 'Perfil Principal' }];
-      const defaultDays = { [INITIAL_DAY_ID]: getInitialDayState(INITIAL_SLOT_KEYS) };
-      saveState(makeProfileKey(defaultId, 'profile'), DEFAULT_PROFILE);
-      saveState(makeProfileKey(defaultId, 'slots'), INITIAL_SLOT_KEYS);
-      saveState(makeProfileKey(defaultId, 'days'), defaultDays);
-      saveState(makeProfileKey(defaultId, 'current_day'), INITIAL_DAY_ID);
-    }
+        if (profilesList.length === 0) {
+          const singleProfile = loadState(PROFILE_STORAGE_KEY, null);
+          const legacyProfile = singleProfile || loadState(LEGACY_PROFILE_STORAGE_KEY, null);
+          const legacySlots = loadState(LEGACY_SLOTS_STORAGE_KEY, null);
+          const legacyDays = loadState(LEGACY_ALL_DAYS_STORAGE_KEY, null);
+          const legacyCurrentDay = loadState(LEGACY_CURRENT_DAY_ID_STORAGE_KEY, null);
+          const migratedId = generateProfileId();
+          const migratedName = legacyProfile && typeof legacyProfile.name === 'string' && legacyProfile.name.trim().length>0 ? legacyProfile.name.trim() : 'Perfil Principal';
+          const migratedSlots = Array.isArray(legacySlots) && legacySlots.length>0 ? legacySlots : INITIAL_SLOT_KEYS;
+          const migratedDays = normalizeDays(legacyDays, migratedSlots);
+          const migratedCurrentDay = migratedDays[legacyCurrentDay] ? legacyCurrentDay : Object.keys(migratedDays)[0] || INITIAL_DAY_ID;
+          profilesList = [{ id: migratedId, name: migratedName }];
+          const migratedProfile = legacyProfile ? sanitizeProfile({ ...DEFAULT_PROFILE, ...legacyProfile }) : DEFAULT_PROFILE;
+          saveState(makeProfileKey(migratedId, 'profile'), migratedProfile);
+          saveState(makeProfileKey(migratedId, 'slots'), migratedSlots);
+          saveState(makeProfileKey(migratedId, 'days'), migratedDays);
+          saveState(makeProfileKey(migratedId, 'current_day'), migratedCurrentDay);
+          removeState(PROFILE_STORAGE_KEY);
+          removeState(LEGACY_PROFILE_STORAGE_KEY);
+        }
 
-    let selectedId = loadState(SELECTED_PROFILE_ID_KEY, profilesList[0]?.id || null);
-    if (!profilesList.some(p=>p.id===selectedId)) selectedId = profilesList[0]?.id || null;
+        if (profilesList.length === 0) {
+          const defaultId = generateProfileId();
+          profilesList = [{ id: defaultId, name: 'Perfil Principal' }];
+          const defaultDays = { [INITIAL_DAY_ID]: getInitialDayState(INITIAL_SLOT_KEYS) };
+          saveState(makeProfileKey(defaultId, 'profile'), DEFAULT_PROFILE);
+          saveState(makeProfileKey(defaultId, 'slots'), INITIAL_SLOT_KEYS);
+          saveState(makeProfileKey(defaultId, 'days'), defaultDays);
+          saveState(makeProfileKey(defaultId, 'current_day'), INITIAL_DAY_ID);
+        }
 
-    saveState(PROFILES_INDEX_KEY, profilesList);
-    if (selectedId) saveState(SELECTED_PROFILE_ID_KEY, selectedId);
+        let selectedId = loadState(SELECTED_PROFILE_ID_KEY, profilesList[0]?.id || null);
+        if (!profilesList.some(p=>p.id===selectedId)) selectedId = profilesList[0]?.id || null;
 
-    setProfiles(profilesList);
-    setSelectedProfileId(selectedId);
+        saveState(PROFILES_INDEX_KEY, profilesList);
+        if (selectedId) saveState(SELECTED_PROFILE_ID_KEY, selectedId);
 
-    if (selectedId) {
-      const bundle = loadProfileBundle(selectedId);
-      setProfile(bundle.profile);
-      setSlotKeys(bundle.slotKeys);
-      setAllDays(bundle.allDays);
-      setCurrentDayId(bundle.currentDayId);
-      const activeMeta = profilesList.find(p=>p.id===selectedId);
-      setProfileNameDraft(activeMeta ? activeMeta.name : '');
-    }
+        if (cancelled) return;
+        setProfiles(profilesList);
+        setSelectedProfileId(selectedId);
 
-    setIsInitialized(true);
-    setIsProfileHydrating(false);
+        if (selectedId) {
+          const bundle = loadProfileBundle(selectedId);
+          if (cancelled) return;
+          setProfile(bundle.profile);
+          setSlotKeys(bundle.slotKeys);
+          setAllDays(bundle.allDays);
+          setCurrentDayId(bundle.currentDayId);
+          const activeMeta = profilesList.find(p=>p.id===selectedId);
+          setProfileNameDraft(activeMeta ? activeMeta.name : '');
+        } else {
+          fallbackBootstrap();
+        }
+      } catch (error) {
+        console.error('Falha ao carregar dados locais, aplicando padrão', error);
+        if (!cancelled) fallbackBootstrap();
+      } finally {
+        if (!cancelled) {
+          setIsInitialized(true);
+          setIsProfileHydrating(false);
+        }
+      }
+    };
+
+    bootstrap();
+
+    return () => { cancelled = true; };
   },[]);
 
   useEffect(()=>{

--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>Cardápio Inteligente — MVP v5.6</title>
+  <title>Cardápio Inteligente — MVP v5.7</title>
 
   <!-- Tailwind -->
   <script src="https://cdn.tailwindcss.com"></script>
@@ -26,10 +26,17 @@
 
   <script type="text/babel">
 /* === Estado/Utilidades === */
-const PROFILE_STORAGE_KEY = "cardapio_profile_v5_3";
-const ALL_DAYS_STORAGE_KEY = "cardapio_all_days_v5_6";
-const SLOTS_STORAGE_KEY = "cardapio_slotkeys_v5_6";
-const CURRENT_DAY_ID_STORAGE_KEY = "cardapio_current_day_id_v5_6";
+const PROFILE_STORAGE_KEY = 'dietacardapio_profile_v1';
+const LEGACY_PROFILE_STORAGE_KEY = "cardapio_profile_v5_3";
+const LEGACY_ALL_DAYS_STORAGE_KEY = "cardapio_all_days_v5_6";
+const LEGACY_SLOTS_STORAGE_KEY = "cardapio_slotkeys_v5_6";
+const LEGACY_CURRENT_DAY_ID_STORAGE_KEY = "cardapio_current_day_id_v5_6";
+
+const STORAGE_NAMESPACE = "cardapio_v6";
+const PROFILES_INDEX_KEY = `${STORAGE_NAMESPACE}_profiles_index`;
+const SELECTED_PROFILE_ID_KEY = `${STORAGE_NAMESPACE}_selected_profile_id`;
+const makeProfileKey = (profileId, segment) => `${STORAGE_NAMESPACE}_${segment}_${profileId}`;
+
 const INITIAL_DAY_ID = 'day-1';
 
 const INPUT_RANGES = {
@@ -52,25 +59,20 @@ function normalizeAndValidateInput(key, value) {
   return numericValue;
 }
 
+const resolveStaticAsset = (relativePath) => {
+  try {
+    return new URL(relativePath, window.location.href).toString();
+  } catch (e) {
+    console.warn("Falha ao resolver caminho estático", relativePath, e);
+    return relativePath;
+  }
+};
+
 const loadState = (key, defaultState) => {
   try {
     const raw = localStorage.getItem(key);
     if (raw === null || raw === "undefined") return defaultState;
     const state = JSON.parse(raw);
-
-    if (key === PROFILE_STORAGE_KEY) {
-      const validated = { ...state };
-      let reset = false;
-      Object.keys(INPUT_RANGES).forEach(k => {
-        const r = INPUT_RANGES[k];
-        const v = Number(state[k]);
-        if (Number.isNaN(v) || v < r.min || v > r.max) { validated[k] = DEFAULT_PROFILE[k]; reset = true; }
-      });
-      if (!['M','F'].includes(state.sex)) { validated.sex = DEFAULT_PROFILE.sex; reset = true; }
-      if (!['loss','maintain','gain','recomp'].includes(state.goal)) { validated.goal = DEFAULT_PROFILE.goal; reset = true; }
-      if (reset) console.warn("Perfil: valores inválidos restaurados.");
-      return validated;
-    }
     return state;
   } catch(e){ console.error("loadState", key, e); return defaultState; }
 };
@@ -78,6 +80,20 @@ const loadState = (key, defaultState) => {
 const saveState = (key, state) => {
   try { localStorage.setItem(key, JSON.stringify(state)); }
   catch(e){ console.error("saveState", key, e); }
+};
+
+const removeState = (key) => {
+  try { localStorage.removeItem(key); }
+  catch(e){ console.error("removeState", key, e); }
+};
+
+const generateProfileId = () => {
+  try {
+    if (window.crypto && window.crypto.randomUUID) return window.crypto.randomUUID();
+  } catch (e) {
+    console.warn("randomUUID indisponível", e);
+  }
+  return `profile-${Math.random().toString(36).slice(2,10)}-${Date.now()}`;
 };
 
 /* === Cálculos === */
@@ -128,7 +144,7 @@ function calculateMealMacros(entry){
 }
 
 /* === Dados de refeições (mesmos do seu app) === */
-const MEALS = [
+const DEFAULT_MEALS = [
   { id:"whey_agua", name:"Whey Protein Isolado (Água)", block:"250", tags:["High Protein","Low Carb","Quick"], ingredients:[{ name:"Whey Protein (1 Scoop)", protein:25, carbs:5, fats:4, baseKcal:155 }] },
   { id:"shake_caseina", name:"Shake de Caseína (Pré-Cama)", block:"250", tags:["High Protein","Low Carb"], ingredients:[{ name:"Caseína/Whey", protein:30, carbs:4, fats:3, baseKcal:170 }] },
   { id:"ovo_cozido", name:"2 Ovos Cozidos", block:"250", tags:["High Protein","Low Carb","High Fat"], ingredients:[{ name:"Ovo Cozido (2 unid.)", protein:12, carbs:1, fats:10, baseKcal:140 }] },
@@ -144,14 +160,13 @@ const MEALS = [
   { id:"massa_pesto_frango_azeitonas", name:"Massa Integral c/ Pesto, Frango e Azeitonas", block:"750", tags:["High Carb","High Protein","Post-Workout"], ingredients:[{ name:"Massa Integral Cozida (150g)", protein:7, carbs:45, fats:2, baseKcal:230 }, { name:"Peito de Frango Picado (150g)", protein:40, carbs:0, fats:6, baseKcal:226 }, { name:"Molho Pesto (2 col. sopa)", protein:5, carbs:5, fats:20, baseKcal:220 }, { name:"Tomate Seco e Azeitonas", protein:0, carbs:5, fats:6, baseKcal:70 }] },
 ];
 
-const MEALS_WITH_TOTALS = MEALS.map(meal => {
+const addTotalsToMeals = (mealsList) => mealsList.map(meal => {
   const totals = meal.ingredients.reduce((acc, ing) => {
     const m = calculateMealMacros({ ...ing, portion: 1 });
     acc.protein+=m.protein; acc.carbs+=m.carbs; acc.fats+=m.fats; acc.kcal+=m.kcal; return acc;
   }, { protein:0, carbs:0, fats:0, kcal:0 });
   return { ...meal, ...totals };
 });
-const TAGS = ["High Protein","Low Carb","High Carb","Plant-Based","Balanced","High Fat Saudável","Low Protein","High Fat","Post-Workout","Quick","Bulk","BR"];
 const PORTION_OPTIONS = [0.5, 1, 1.5, 2];
 
 const MinimizeButton = ({ isMinimized, toggleMinimize }) => (
@@ -191,31 +206,184 @@ function Section({ title, children, right, isMinimized }) {
 }
 
 const DEFAULT_PROFILE = { sex:"M", age:33, weight:73, height:170, activity:"moderate", goal:"recomp", neck:36, waist:85, hip:95, photoUrl:'https://placehold.co/100x100/1E293B/E2E8F0?text=Foto' };
+
+function sanitizeProfile(rawProfile) {
+  const candidate = { ...DEFAULT_PROFILE, ...(rawProfile || {}) };
+  const validated = { ...candidate };
+  let reset = false;
+
+  Object.keys(INPUT_RANGES).forEach(k => {
+    const range = INPUT_RANGES[k];
+    const value = Number(candidate[k]);
+    if (Number.isNaN(value) || value < range.min || value > range.max) {
+      validated[k] = DEFAULT_PROFILE[k];
+      reset = true;
+    }
+  });
+
+  if (!['M','F'].includes(candidate.sex)) { validated.sex = DEFAULT_PROFILE.sex; reset = true; }
+  if (!['loss','maintain','gain','recomp'].includes(candidate.goal)) { validated.goal = DEFAULT_PROFILE.goal; reset = true; }
+
+  if (reset) console.warn("Perfil: valores inválidos restaurados.");
+  return validated;
+}
 const INITIAL_SLOT_KEYS = [`slot-1`,`slot-2`,`slot-3`,`slot-4`];
 const getInitialDayState = (keys) => keys.reduce((acc,k)=>({ ...acc, [k]:[] }),{});
+const normalizeDays = (days, slotKeys) => {
+  const base = days && typeof days === 'object' ? days : {};
+  const normalized = {};
+  const validSlots = Array.isArray(slotKeys) && slotKeys.length>0 ? slotKeys : INITIAL_SLOT_KEYS;
+  const dayIds = Object.keys(base).length>0 ? Object.keys(base) : [INITIAL_DAY_ID];
+  dayIds.forEach(id => {
+    const dayData = base[id] && typeof base[id] === 'object' ? base[id] : {};
+    normalized[id] = validSlots.reduce((acc, slot)=>({ ...acc, [slot]: Array.isArray(dayData[slot]) ? dayData[slot] : [] }), {});
+  });
+  return normalized;
+};
+const loadProfileBundle = (profileId) => {
+  const storedProfile = sanitizeProfile(loadState(makeProfileKey(profileId, 'profile'), DEFAULT_PROFILE));
+  const storedSlots = loadState(makeProfileKey(profileId, 'slots'), INITIAL_SLOT_KEYS);
+  const slotKeys = Array.isArray(storedSlots) && storedSlots.length>0 ? storedSlots : INITIAL_SLOT_KEYS;
+  const storedDays = loadState(makeProfileKey(profileId, 'days'), { [INITIAL_DAY_ID]: getInitialDayState(slotKeys) });
+  const normalizedDays = normalizeDays(storedDays, slotKeys);
+  const storedCurrentDay = loadState(makeProfileKey(profileId, 'current_day'), Object.keys(normalizedDays)[0] || INITIAL_DAY_ID);
+  const currentDayId = normalizedDays[storedCurrentDay] ? storedCurrentDay : Object.keys(normalizedDays)[0] || INITIAL_DAY_ID;
+  return {
+    profile: storedProfile,
+    slotKeys,
+    allDays: normalizedDays,
+    currentDayId,
+  };
+};
 
 function App(){
   const { useMemo, useState, useEffect } = React;
 
   /* Estado + persistência */
-  const [profile, setProfile] = useState(()=>loadState(PROFILE_STORAGE_KEY, DEFAULT_PROFILE));
+  const [profiles, setProfiles] = useState([]);
+  const [selectedProfileId, setSelectedProfileId] = useState(null);
+  const [profile, setProfile] = useState(DEFAULT_PROFILE);
   const [isProfileLocked, setIsProfileLocked] = useState(false);
-  const [slotKeys, setSlotKeys] = useState(()=> {
-    const k = loadState(SLOTS_STORAGE_KEY, INITIAL_SLOT_KEYS);
-    return Array.isArray(k) && k.length>0 ? k : INITIAL_SLOT_KEYS;
-  });
-  const [currentDayId, setCurrentDayId] = useState(()=>loadState(CURRENT_DAY_ID_STORAGE_KEY, INITIAL_DAY_ID));
-  const [allDays, setAllDays] = useState(()=> {
-    const d = loadState(ALL_DAYS_STORAGE_KEY, {});
-    if (Object.keys(d).length===0 || !d[INITIAL_DAY_ID]) return { [INITIAL_DAY_ID]: getInitialDayState(INITIAL_SLOT_KEYS) };
-    return d;
-  });
+  const [slotKeys, setSlotKeys] = useState(INITIAL_SLOT_KEYS);
+  const [currentDayId, setCurrentDayId] = useState(INITIAL_DAY_ID);
+  const [allDays, setAllDays] = useState({ [INITIAL_DAY_ID]: getInitialDayState(INITIAL_SLOT_KEYS) });
+  const [isInitialized, setIsInitialized] = useState(false);
+  const [isProfileHydrating, setIsProfileHydrating] = useState(true);
+  const [profileNameDraft, setProfileNameDraft] = useState('');
+  const [isAddingProfile, setIsAddingProfile] = useState(false);
+  const [newProfileName, setNewProfileName] = useState('');
   const day = allDays[currentDayId] || getInitialDayState(slotKeys);
 
-  useEffect(()=>{ saveState(PROFILE_STORAGE_KEY, profile); },[profile]);
-  useEffect(()=>{ saveState(ALL_DAYS_STORAGE_KEY, allDays); },[allDays]);
-  useEffect(()=>{ saveState(CURRENT_DAY_ID_STORAGE_KEY, currentDayId); },[currentDayId]);
-  useEffect(()=>{ saveState(SLOTS_STORAGE_KEY, slotKeys); },[slotKeys]);
+  useEffect(()=>{
+    setIsProfileHydrating(true);
+    let profilesList = [];
+    const storedProfiles = loadState(PROFILES_INDEX_KEY, null);
+    if (Array.isArray(storedProfiles)) {
+      profilesList = storedProfiles.filter(p=>p && p.id && p.name);
+    }
+
+    if (profilesList.length === 0) {
+      const singleProfile = loadState(PROFILE_STORAGE_KEY, null);
+      const legacyProfile = singleProfile || loadState(LEGACY_PROFILE_STORAGE_KEY, null);
+      const legacySlots = loadState(LEGACY_SLOTS_STORAGE_KEY, null);
+      const legacyDays = loadState(LEGACY_ALL_DAYS_STORAGE_KEY, null);
+      const legacyCurrentDay = loadState(LEGACY_CURRENT_DAY_ID_STORAGE_KEY, null);
+      const migratedId = generateProfileId();
+      const migratedName = legacyProfile && typeof legacyProfile.name === 'string' && legacyProfile.name.trim().length>0 ? legacyProfile.name.trim() : 'Perfil Principal';
+      const migratedSlots = Array.isArray(legacySlots) && legacySlots.length>0 ? legacySlots : INITIAL_SLOT_KEYS;
+      const migratedDays = normalizeDays(legacyDays, migratedSlots);
+      const migratedCurrentDay = migratedDays[legacyCurrentDay] ? legacyCurrentDay : Object.keys(migratedDays)[0] || INITIAL_DAY_ID;
+      profilesList = [{ id: migratedId, name: migratedName }];
+      const migratedProfile = legacyProfile ? sanitizeProfile({ ...DEFAULT_PROFILE, ...legacyProfile }) : DEFAULT_PROFILE;
+      saveState(makeProfileKey(migratedId, 'profile'), migratedProfile);
+      saveState(makeProfileKey(migratedId, 'slots'), migratedSlots);
+      saveState(makeProfileKey(migratedId, 'days'), migratedDays);
+      saveState(makeProfileKey(migratedId, 'current_day'), migratedCurrentDay);
+      removeState(PROFILE_STORAGE_KEY);
+      removeState(LEGACY_PROFILE_STORAGE_KEY);
+    }
+
+    if (profilesList.length === 0) {
+      const defaultId = generateProfileId();
+      profilesList = [{ id: defaultId, name: 'Perfil Principal' }];
+      const defaultDays = { [INITIAL_DAY_ID]: getInitialDayState(INITIAL_SLOT_KEYS) };
+      saveState(makeProfileKey(defaultId, 'profile'), DEFAULT_PROFILE);
+      saveState(makeProfileKey(defaultId, 'slots'), INITIAL_SLOT_KEYS);
+      saveState(makeProfileKey(defaultId, 'days'), defaultDays);
+      saveState(makeProfileKey(defaultId, 'current_day'), INITIAL_DAY_ID);
+    }
+
+    let selectedId = loadState(SELECTED_PROFILE_ID_KEY, profilesList[0]?.id || null);
+    if (!profilesList.some(p=>p.id===selectedId)) selectedId = profilesList[0]?.id || null;
+
+    saveState(PROFILES_INDEX_KEY, profilesList);
+    if (selectedId) saveState(SELECTED_PROFILE_ID_KEY, selectedId);
+
+    setProfiles(profilesList);
+    setSelectedProfileId(selectedId);
+
+    if (selectedId) {
+      const bundle = loadProfileBundle(selectedId);
+      setProfile(bundle.profile);
+      setSlotKeys(bundle.slotKeys);
+      setAllDays(bundle.allDays);
+      setCurrentDayId(bundle.currentDayId);
+      const activeMeta = profilesList.find(p=>p.id===selectedId);
+      setProfileNameDraft(activeMeta ? activeMeta.name : '');
+    }
+
+    setIsInitialized(true);
+    setIsProfileHydrating(false);
+  },[]);
+
+  useEffect(()=>{
+    if (!isInitialized || !selectedProfileId) return;
+    setIsProfileHydrating(true);
+    const bundle = loadProfileBundle(selectedProfileId);
+    setProfile(bundle.profile);
+    setSlotKeys(bundle.slotKeys);
+    setAllDays(bundle.allDays);
+    setCurrentDayId(bundle.currentDayId);
+    const activeMeta = profiles.find(p=>p.id===selectedProfileId);
+    setProfileNameDraft(activeMeta ? activeMeta.name : '');
+    setIsProfileHydrating(false);
+  },[selectedProfileId, isInitialized]);
+
+  useEffect(()=>{
+    if (!isInitialized) return;
+    const activeMeta = profiles.find(p=>p.id===selectedProfileId);
+    setProfileNameDraft(activeMeta ? activeMeta.name : '');
+  },[profiles, selectedProfileId, isInitialized]);
+
+  useEffect(()=>{
+    if (!isInitialized) return;
+    saveState(PROFILES_INDEX_KEY, profiles);
+  },[profiles, isInitialized]);
+
+  useEffect(()=>{
+    if (!isInitialized || !selectedProfileId) return;
+    saveState(SELECTED_PROFILE_ID_KEY, selectedProfileId);
+  },[selectedProfileId, isInitialized]);
+
+  useEffect(()=>{
+    if (!isInitialized || !selectedProfileId || isProfileHydrating) return;
+    saveState(makeProfileKey(selectedProfileId, 'profile'), profile);
+  },[profile, selectedProfileId, isInitialized, isProfileHydrating]);
+
+  useEffect(()=>{
+    if (!isInitialized || !selectedProfileId || isProfileHydrating) return;
+    saveState(makeProfileKey(selectedProfileId, 'days'), allDays);
+  },[allDays, selectedProfileId, isInitialized, isProfileHydrating]);
+
+  useEffect(()=>{
+    if (!isInitialized || !selectedProfileId || isProfileHydrating) return;
+    saveState(makeProfileKey(selectedProfileId, 'current_day'), currentDayId);
+  },[currentDayId, selectedProfileId, isInitialized, isProfileHydrating]);
+
+  useEffect(()=>{
+    if (!isInitialized || !selectedProfileId || isProfileHydrating) return;
+    saveState(makeProfileKey(selectedProfileId, 'slots'), slotKeys);
+  },[slotKeys, selectedProfileId, isInitialized, isProfileHydrating]);
 
   /* UI */
   const [isProfileMinimized, setIsProfileMinimized] = useState(false);
@@ -225,6 +393,80 @@ function App(){
   const [selectedBlock, setSelectedBlock] = useState("all");
   const [activeTags, setActiveTags] = useState([]);
   const [search, setSearch] = useState("");
+  const [meals, setMeals] = useState(DEFAULT_MEALS);
+  const [isMealsLoading, setIsMealsLoading] = useState(true);
+  const [mealsError, setMealsError] = useState('');
+
+  const handleSelectProfile = (id) => {
+    if (!id || id === selectedProfileId) return;
+    setIsProfileHydrating(true);
+    setSelectedProfileId(id);
+    setIsAddingProfile(false);
+  };
+
+  const finalizeProfileName = () => {
+    if (!selectedProfileId) return;
+    const trimmed = profileNameDraft.trim();
+    const fallbackIndex = Math.max(1, profiles.findIndex(p=>p.id===selectedProfileId) + 1);
+    const finalName = trimmed.length>0 ? trimmed : `Perfil ${fallbackIndex}`;
+    setProfiles(prev=> prev.map(p=> p.id===selectedProfileId ? { ...p, name: finalName } : p));
+    setProfileNameDraft(finalName);
+  };
+
+  const handleCreateProfile = (name) => {
+    const trimmed = name.trim();
+    const finalName = trimmed.length>0 ? trimmed : `Perfil ${profiles.length+1}`;
+    const newId = generateProfileId();
+    const defaultDays = { [INITIAL_DAY_ID]: getInitialDayState(INITIAL_SLOT_KEYS) };
+    saveState(makeProfileKey(newId, 'profile'), DEFAULT_PROFILE);
+    saveState(makeProfileKey(newId, 'slots'), INITIAL_SLOT_KEYS);
+    saveState(makeProfileKey(newId, 'days'), defaultDays);
+    saveState(makeProfileKey(newId, 'current_day'), INITIAL_DAY_ID);
+    setProfiles(prev=> [...prev, { id: newId, name: finalName }]);
+    setIsProfileHydrating(true);
+    setProfile(DEFAULT_PROFILE);
+    setSlotKeys(INITIAL_SLOT_KEYS);
+    setAllDays(defaultDays);
+    setCurrentDayId(INITIAL_DAY_ID);
+    setProfileNameDraft(finalName);
+    setSelectedProfileId(newId);
+    setIsAddingProfile(false);
+    setNewProfileName('');
+  };
+
+  const handleDeleteProfile = () => {
+    if (profiles.length<=1 || !selectedProfileId) return;
+    const activeMeta = profiles.find(p=>p.id===selectedProfileId);
+    const ok = window.confirm(`Excluir o perfil "${activeMeta?.name || 'Atual'}"? Esta ação não pode ser desfeita.`);
+    if (!ok) return;
+    removeState(makeProfileKey(selectedProfileId, 'profile'));
+    removeState(makeProfileKey(selectedProfileId, 'slots'));
+    removeState(makeProfileKey(selectedProfileId, 'days'));
+    removeState(makeProfileKey(selectedProfileId, 'current_day'));
+    const remaining = profiles.filter(p=>p.id!==selectedProfileId);
+    setProfiles(remaining);
+    const nextId = remaining[0]?.id || null;
+    if (nextId) {
+      setIsProfileHydrating(true);
+      setSelectedProfileId(nextId);
+    } else {
+      const fallbackId = generateProfileId();
+      const fallbackMeta = { id: fallbackId, name: 'Perfil Principal' };
+      const fallbackDays = { [INITIAL_DAY_ID]: getInitialDayState(INITIAL_SLOT_KEYS) };
+      setProfiles([fallbackMeta]);
+      setIsProfileHydrating(true);
+      setSelectedProfileId(fallbackId);
+      setProfile(DEFAULT_PROFILE);
+      setSlotKeys(INITIAL_SLOT_KEYS);
+      setAllDays(fallbackDays);
+      setCurrentDayId(INITIAL_DAY_ID);
+      setProfileNameDraft(fallbackMeta.name);
+      saveState(makeProfileKey(fallbackId, 'profile'), DEFAULT_PROFILE);
+      saveState(makeProfileKey(fallbackId, 'slots'), INITIAL_SLOT_KEYS);
+      saveState(makeProfileKey(fallbackId, 'days'), fallbackDays);
+      saveState(makeProfileKey(fallbackId, 'current_day'), INITIAL_DAY_ID);
+    }
+  };
 
   /* <<< CORREÇÃO: edição suave + clamp no onBlur >>> */
   const handleProfileChange = (key, value) => {
@@ -249,6 +491,37 @@ function App(){
     if (file) setProfile(p => ({ ...p, photoUrl: URL.createObjectURL(file) }));
   };
 
+  useEffect(()=>{
+    let isMounted = true;
+    setIsMealsLoading(true);
+    const alimentosUrl = resolveStaticAsset('./alimentos.json');
+    fetch(alimentosUrl, { cache: 'no-store' })
+      .then(res => {
+        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+        return res.json();
+      })
+      .then(data => {
+        if (!isMounted) return;
+        const parsed = Array.isArray(data) ? data : Array.isArray(data?.meals) ? data.meals : [];
+        if (parsed.length>0) {
+          setMeals(parsed);
+          setMealsError('');
+        } else {
+          setMeals(DEFAULT_MEALS);
+          setMealsError('');
+        }
+        setIsMealsLoading(false);
+      })
+      .catch(err => {
+        if (!isMounted) return;
+        console.error('Erro ao carregar alimentos externos', err);
+        setMeals(DEFAULT_MEALS);
+        setMealsError('Não foi possível carregar o cardápio externo. Usando lista padrão.');
+        setIsMealsLoading(false);
+      });
+    return () => { isMounted = false; };
+  },[]);
+
   /* Cálculos memoizados */
   const bmr = useMemo(()=>calcBMR(profile),[profile]);
   const tdee = useMemo(()=>calcTDEE(bmr, profile.activity),[bmr, profile.activity]);
@@ -256,23 +529,53 @@ function App(){
   const macroTargets = useMemo(()=>deriveMacroTargets({ weight: Number(profile.weight)||0, calories: targetCalories }),[profile.weight, targetCalories]);
   const bodyFat = useMemo(()=>{ const v = calcBF({ ...profile, height:Number(profile.height)||0, neck:Number(profile.neck)||0, waist:Number(profile.waist)||0, hip:Number(profile.hip)||0 }); return v!=null ? round(v,1) : null; },[profile.sex, profile.height, profile.neck, profile.waist, profile.hip]);
 
-  const filteredMeals = useMemo(()=> MEALS_WITH_TOTALS.filter(m=>{
+  const mealsWithTotals = useMemo(()=> addTotalsToMeals(meals && meals.length>0 ? meals : DEFAULT_MEALS),[meals]);
+  const availableTags = useMemo(()=> {
+    const tags = new Set();
+    mealsWithTotals.forEach(meal => {
+      (meal.tags || []).forEach(tag => tags.add(tag));
+    });
+    return Array.from(tags).sort((a,b)=>a.localeCompare(b));
+  },[mealsWithTotals]);
+
+  const filteredMeals = useMemo(()=> mealsWithTotals.filter(m=>{
+    const tags = Array.isArray(m.tags) ? m.tags : [];
     const blockOk = selectedBlock==="all" || m.block===selectedBlock;
-    const tagOk = activeTags.length===0 || activeTags.every(t=>m.tags.includes(t));
-    const searchOk = m.name.toLowerCase().includes(search.toLowerCase());
+    const tagOk = activeTags.length===0 || activeTags.every(t=>tags.includes(t));
+    const query = search.trim().toLowerCase();
+    const searchOk = query.length===0 || m.name.toLowerCase().includes(query);
     return blockOk && tagOk && searchOk;
-  }),[selectedBlock, activeTags, search]);
+  }),[selectedBlock, activeTags, search, mealsWithTotals]);
 
   const totals = useMemo(()=>{
-    const all = Object.values(day).flat();
+    const all = Object.values(day || {}).flat();
     return all.reduce((acc, mealEntry)=>{
-      const mealTotals = mealEntry.ingredients.reduce((a, ing)=>{
-        const m = calculateMealMacros(ing);
-        a.kcal+=m.kcal; a.protein+=m.protein; a.carbs+=m.carbs; a.fats+=m.fats; return a;
-      },{kcal:0,protein:0,carbs:0,fats:0});
-      acc.kcal+=mealTotals.kcal; acc.protein+=mealTotals.protein; acc.carbs+=mealTotals.carbs; acc.fats+=mealTotals.fats; return acc;
+      const mealTotals = Array.isArray(mealEntry?.ingredients) ? mealEntry.ingredients.reduce((inner, ing)=>{
+        const macros = calculateMealMacros({ ...ing, portion: ing.portion ?? 1 });
+        inner.kcal += macros.kcal;
+        inner.protein += macros.protein;
+        inner.carbs += macros.carbs;
+        inner.fats += macros.fats;
+        return inner;
+      },{kcal:0,protein:0,carbs:0,fats:0}) : { kcal:0,protein:0,carbs:0,fats:0 };
+      acc.kcal += mealTotals.kcal;
+      acc.protein += mealTotals.protein;
+      acc.carbs += mealTotals.carbs;
+      acc.fats += mealTotals.fats;
+      return acc;
     },{kcal:0,protein:0,carbs:0,fats:0});
   },[day]);
+
+  if (!isInitialized) {
+    return (
+      <div className="min-h-screen bg-[#0a0a1a] text-slate-200 font-inter flex items-center justify-center">
+        <div className="text-center space-y-2">
+          <h1 className="text-xl font-semibold text-white">Carregando seus dados locais...</h1>
+          <p className="text-sm text-slate-400">Aguarde enquanto verificamos perfis e refeições salvas neste dispositivo.</p>
+        </div>
+      </div>
+    );
+  }
 
   const getSlotLabel = (key)=>{ const i = slotKeys.indexOf(key); return i===-1 ? key : `Refeição ${i+1}`; };
   const updateDay = (newDay)=> setAllDays(prev=>({ ...prev, [currentDayId]: newDay }));
@@ -360,7 +663,7 @@ function App(){
         <div className="max-w-7xl mx-auto flex items-center justify-between">
           <div>
             <h1 className="text-2xl font-bold tracking-tight text-white">Cardápio Inteligente</h1>
-            <p className="text-sm text-slate-400">Monte seu dia com porções ajustáveis e metas calculadas (v5.6)</p>
+            <p className="text-sm text-slate-400">Monte seu dia com porções ajustáveis e metas calculadas (v5.7)</p>
           </div>
           <div className="hidden md:flex items-center gap-3">
             <a href="#biblioteca" className="text-sm px-3 py-1 rounded border border-slate-600 hover:bg-slate-700/40 transition">Biblioteca</a>
@@ -385,6 +688,40 @@ function App(){
             </div>
 
             <div className="mt-4">
+              <div className="mb-5 space-y-4">
+                <div>
+                  <label className="text-xs uppercase tracking-wide text-slate-400 block mb-2">Perfil ativo neste dispositivo</label>
+                  <div className="flex flex-col sm:flex-row sm:items-center gap-2">
+                    <select value={selectedProfileId || ''} onChange={(e)=>handleSelectProfile(e.target.value)} className="bg-slate-900 border border-slate-600 rounded px-3 py-2 text-sm focus:ring-emerald-500 focus:border-emerald-500">
+                      {profiles.map(meta=> (<option key={meta.id} value={meta.id}>{meta.name}</option>))}
+                    </select>
+                    <div className="flex gap-2">
+                      <button onClick={()=>{ setIsAddingProfile(true); setNewProfileName(''); }} disabled={isAddingProfile} className={`text-xs px-3 py-2 rounded border transition focus:outline-none focus:ring-1 focus:ring-emerald-500 ${isAddingProfile ? 'border-slate-700 text-slate-500 cursor-not-allowed' : 'border-emerald-500 text-emerald-300 hover:bg-emerald-500/10'}`}>+ Novo</button>
+                      <button onClick={handleDeleteProfile} disabled={profiles.length<=1} className={`text-xs px-3 py-2 rounded border transition focus:outline-none focus:ring-1 focus:ring-red-500 ${profiles.length<=1 ? 'border-slate-700 text-slate-500 cursor-not-allowed' : 'border-red-500 text-red-300 hover:bg-red-500/10'}`}>Excluir</button>
+                    </div>
+                  </div>
+                </div>
+
+                <div>
+                  <label className="text-xs text-slate-400 block mb-1">Nome do perfil</label>
+                  <input value={profileNameDraft} onChange={(e)=>setProfileNameDraft(e.target.value)} onBlur={finalizeProfileName} onKeyDown={(e)=>{ if (e.key==='Enter'){ e.preventDefault(); finalizeProfileName(); e.currentTarget.blur(); } }} className="w-full bg-slate-900 border border-slate-600 rounded px-3 py-2 text-sm focus:ring-emerald-500 focus:border-emerald-500" placeholder="Ex.: Leo, Jaque, Bulking" />
+                  <p className="text-[11px] text-slate-500 mt-1">Cada perfil guarda metas, refeições e slots de forma independente.</p>
+                </div>
+
+                {isAddingProfile && (
+                  <form onSubmit={(e)=>{ e.preventDefault(); handleCreateProfile(newProfileName); }} className="bg-slate-900/60 border border-slate-700 rounded-xl p-3 flex flex-col sm:flex-row sm:items-center gap-3">
+                    <input value={newProfileName} onChange={(e)=>setNewProfileName(e.target.value)} className="flex-1 bg-slate-950 border border-slate-700 rounded px-3 py-2 text-sm focus:ring-emerald-500 focus:border-emerald-500" placeholder="Nome do novo perfil" autoFocus />
+                    <div className="flex gap-2">
+                      <button type="submit" className="text-xs px-3 py-2 rounded border border-emerald-500 text-emerald-300 hover:bg-emerald-500/10 transition focus:outline-none focus:ring-1 focus:ring-emerald-500">Salvar</button>
+                      <button type="button" onClick={()=>{ setIsAddingProfile(false); setNewProfileName(''); }} className="text-xs px-3 py-2 rounded border border-slate-600 text-slate-400 hover:bg-slate-800/60 transition focus:outline-none focus:ring-1 focus:ring-slate-500">Cancelar</button>
+                    </div>
+                  </form>
+                )}
+
+                {isProfileHydrating && (
+                  <p className="text-xs text-slate-400">Carregando dados do perfil selecionado...</p>
+                )}
+              </div>
               <ProfilePhotoUploader photoUrl={profile.photoUrl} handleUpload={handlePhotoUpload} isDisabled={isProfileLocked}/>
               {!isProfileMinimized && (
                 <div className={`${isProfileLocked ? 'opacity-70 cursor-not-allowed':''}`} title={isProfileLocked ? "Perfil trancado" : undefined}>
@@ -519,7 +856,7 @@ function App(){
             }
           >
             <div className="flex flex-wrap mb-3">
-              {TAGS.map(t=>(
+              {availableTags.map(t=>(
                 <Pill key={t} active={activeTags.includes(t)} onClick={()=>setActiveTags(prev=> prev.includes(t) ? prev.filter(x=>x!==t) : [...prev,t])}>{t}</Pill>
               ))}
               {activeTags.length>0 && (
@@ -528,6 +865,9 @@ function App(){
             </div>
 
             <div id="biblioteca" className="grid md:grid-cols-2 gap-4 max-h-[500px] overflow-y-auto pr-2">
+              {isMealsLoading && (
+                <div className="text-slate-400 text-sm md:col-span-2 p-4 border border-dashed border-slate-700 rounded-xl text-center">Carregando cardápio atualizado...</div>
+              )}
               {filteredMeals.map(m=>(
                 <div key={m.id} className="rounded-xl border border-slate-700 bg-slate-900 p-4 transition-shadow hover:shadow-emerald-500/10 hover:shadow-xl">
                   <div className="flex items-start justify-between">
@@ -547,10 +887,11 @@ function App(){
                   </div>
                 </div>
               ))}
-              {filteredMeals.length===0 && (
+              {!isMealsLoading && filteredMeals.length===0 && (
                 <div className="text-slate-400 text-sm md:col-span-2 p-4 border border-dashed border-slate-700 rounded-xl text-center">Nenhuma refeição encontrada. Limpe os filtros.</div>
               )}
             </div>
+            {mealsError && <p className="text-xs text-amber-300 mt-2">{mealsError}</p>}
           </Section>
 
           {/* Meu Dia */}
@@ -637,7 +978,7 @@ function App(){
       </main>
 
       <footer className="max-w-7xl mx-auto px-6 py-10 text-center text-xs text-slate-500">
-        MVP visual v5.6. Planejamento multi-dia + duplicação de planos.
+        MVP visual v5.7. Perfis locais independentes + cardápio carregado via JSON.
       </footer>
     </div>
   );

--- a/index.html
+++ b/index.html
@@ -270,129 +270,109 @@ const loadProfileBundle = (profileId) => {
   };
 };
 
+function bootstrapProfilesFromStorage() {
+  let profilesList = [];
+  const storedProfiles = loadState(PROFILES_INDEX_KEY, null);
+  if (Array.isArray(storedProfiles)) {
+    profilesList = storedProfiles.filter(p => p && p.id && p.name);
+  }
+
+  if (profilesList.length === 0) {
+    const singleProfile = loadState(PROFILE_STORAGE_KEY, null);
+    const legacyProfile = singleProfile || loadState(LEGACY_PROFILE_STORAGE_KEY, null);
+    const legacySlots = loadState(LEGACY_SLOTS_STORAGE_KEY, null);
+    const legacyDays = loadState(LEGACY_ALL_DAYS_STORAGE_KEY, null);
+    const legacyCurrentDay = loadState(LEGACY_CURRENT_DAY_ID_STORAGE_KEY, null);
+
+    if (legacyProfile || legacySlots || legacyDays) {
+      const migratedId = generateProfileId();
+      const migratedName = legacyProfile && typeof legacyProfile.name === 'string' && legacyProfile.name.trim().length>0
+        ? legacyProfile.name.trim()
+        : 'Perfil Principal';
+      const migratedSlots = Array.isArray(legacySlots) && legacySlots.length>0 ? legacySlots : INITIAL_SLOT_KEYS;
+      const migratedDays = normalizeDays(legacyDays, migratedSlots);
+      const migratedCurrentDay = migratedDays[legacyCurrentDay] ? legacyCurrentDay : Object.keys(migratedDays)[0] || INITIAL_DAY_ID;
+      const migratedProfile = legacyProfile ? sanitizeProfile({ ...DEFAULT_PROFILE, ...legacyProfile }) : DEFAULT_PROFILE;
+
+      profilesList = [{ id: migratedId, name: migratedName }];
+      saveState(makeProfileKey(migratedId, 'profile'), migratedProfile);
+      saveState(makeProfileKey(migratedId, 'slots'), migratedSlots);
+      saveState(makeProfileKey(migratedId, 'days'), migratedDays);
+      saveState(makeProfileKey(migratedId, 'current_day'), migratedCurrentDay);
+      removeState(PROFILE_STORAGE_KEY);
+      removeState(LEGACY_PROFILE_STORAGE_KEY);
+      removeState(LEGACY_SLOTS_STORAGE_KEY);
+      removeState(LEGACY_ALL_DAYS_STORAGE_KEY);
+      removeState(LEGACY_CURRENT_DAY_ID_STORAGE_KEY);
+    }
+  }
+
+  if (profilesList.length === 0) {
+    const defaultId = generateProfileId();
+    profilesList = [{ id: defaultId, name: 'Perfil Principal' }];
+    const defaultDays = { [INITIAL_DAY_ID]: getInitialDayState(INITIAL_SLOT_KEYS) };
+    saveState(makeProfileKey(defaultId, 'profile'), DEFAULT_PROFILE);
+    saveState(makeProfileKey(defaultId, 'slots'), INITIAL_SLOT_KEYS);
+    saveState(makeProfileKey(defaultId, 'days'), defaultDays);
+    saveState(makeProfileKey(defaultId, 'current_day'), INITIAL_DAY_ID);
+  }
+
+  let selectedId = loadState(SELECTED_PROFILE_ID_KEY, profilesList[0]?.id || null);
+  if (!profilesList.some(p => p.id === selectedId)) {
+    selectedId = profilesList[0]?.id || null;
+  }
+  if (selectedId) {
+    saveState(SELECTED_PROFILE_ID_KEY, selectedId);
+  }
+  saveState(PROFILES_INDEX_KEY, profilesList);
+
+  const bundle = selectedId
+    ? loadProfileBundle(selectedId)
+    : {
+        profile: DEFAULT_PROFILE,
+        slotKeys: INITIAL_SLOT_KEYS,
+        allDays: { [INITIAL_DAY_ID]: getInitialDayState(INITIAL_SLOT_KEYS) },
+        currentDayId: INITIAL_DAY_ID,
+      };
+
+  return {
+    profilesList,
+    selectedId,
+    profile: bundle.profile,
+    slotKeys: bundle.slotKeys,
+    allDays: bundle.allDays,
+    currentDayId: bundle.currentDayId,
+  };
+}
+
 function App(){
-  const { useMemo, useState, useEffect } = React;
+  const { useMemo, useState, useEffect, useRef } = React;
+
+  const bootstrapRef = useRef(null);
+  if (!bootstrapRef.current) {
+    bootstrapRef.current = bootstrapProfilesFromStorage();
+  }
+  const initialData = bootstrapRef.current;
 
   /* Estado + persistência */
-  const [profiles, setProfiles] = useState([]);
-  const [selectedProfileId, setSelectedProfileId] = useState(null);
-  const [profile, setProfile] = useState(DEFAULT_PROFILE);
+  const [profiles, setProfiles] = useState(initialData.profilesList);
+  const [selectedProfileId, setSelectedProfileId] = useState(initialData.selectedId);
+  const [profile, setProfile] = useState(initialData.profile);
   const [isProfileLocked, setIsProfileLocked] = useState(false);
-  const [slotKeys, setSlotKeys] = useState(INITIAL_SLOT_KEYS);
-  const [currentDayId, setCurrentDayId] = useState(INITIAL_DAY_ID);
-  const [allDays, setAllDays] = useState({ [INITIAL_DAY_ID]: getInitialDayState(INITIAL_SLOT_KEYS) });
-  const [isInitialized, setIsInitialized] = useState(false);
-  const [isProfileHydrating, setIsProfileHydrating] = useState(true);
-  const [profileNameDraft, setProfileNameDraft] = useState('');
+  const [slotKeys, setSlotKeys] = useState(initialData.slotKeys);
+  const [currentDayId, setCurrentDayId] = useState(initialData.currentDayId);
+  const [allDays, setAllDays] = useState(initialData.allDays);
+  const [isProfileHydrating, setIsProfileHydrating] = useState(false);
+  const [profileNameDraft, setProfileNameDraft] = useState(() => {
+    const activeMeta = initialData.profilesList.find(p => p.id === initialData.selectedId);
+    return activeMeta ? activeMeta.name : '';
+  });
   const [isAddingProfile, setIsAddingProfile] = useState(false);
   const [newProfileName, setNewProfileName] = useState('');
   const day = allDays[currentDayId] || getInitialDayState(slotKeys);
 
   useEffect(()=>{
-    let cancelled = false;
-    const fallbackBootstrap = () => {
-      const fallbackId = generateProfileId();
-      const fallbackMeta = { id: fallbackId, name: 'Perfil Principal' };
-      const fallbackDays = { [INITIAL_DAY_ID]: getInitialDayState(INITIAL_SLOT_KEYS) };
-      setProfiles([fallbackMeta]);
-      setSelectedProfileId(fallbackId);
-      setProfile(DEFAULT_PROFILE);
-      setSlotKeys(INITIAL_SLOT_KEYS);
-      setAllDays(fallbackDays);
-      setCurrentDayId(INITIAL_DAY_ID);
-      setProfileNameDraft(fallbackMeta.name);
-      try {
-        saveState(makeProfileKey(fallbackId, 'profile'), DEFAULT_PROFILE);
-        saveState(makeProfileKey(fallbackId, 'slots'), INITIAL_SLOT_KEYS);
-        saveState(makeProfileKey(fallbackId, 'days'), fallbackDays);
-        saveState(makeProfileKey(fallbackId, 'current_day'), INITIAL_DAY_ID);
-        saveState(PROFILES_INDEX_KEY, [fallbackMeta]);
-        saveState(SELECTED_PROFILE_ID_KEY, fallbackId);
-      } catch (err) {
-        console.error('Não foi possível salvar estado padrão', err);
-      }
-    };
-
-    const bootstrap = () => {
-      setIsProfileHydrating(true);
-      try {
-        let profilesList = [];
-        const storedProfiles = loadState(PROFILES_INDEX_KEY, null);
-        if (Array.isArray(storedProfiles)) {
-          profilesList = storedProfiles.filter(p=>p && p.id && p.name);
-        }
-
-        if (profilesList.length === 0) {
-          const singleProfile = loadState(PROFILE_STORAGE_KEY, null);
-          const legacyProfile = singleProfile || loadState(LEGACY_PROFILE_STORAGE_KEY, null);
-          const legacySlots = loadState(LEGACY_SLOTS_STORAGE_KEY, null);
-          const legacyDays = loadState(LEGACY_ALL_DAYS_STORAGE_KEY, null);
-          const legacyCurrentDay = loadState(LEGACY_CURRENT_DAY_ID_STORAGE_KEY, null);
-          const migratedId = generateProfileId();
-          const migratedName = legacyProfile && typeof legacyProfile.name === 'string' && legacyProfile.name.trim().length>0 ? legacyProfile.name.trim() : 'Perfil Principal';
-          const migratedSlots = Array.isArray(legacySlots) && legacySlots.length>0 ? legacySlots : INITIAL_SLOT_KEYS;
-          const migratedDays = normalizeDays(legacyDays, migratedSlots);
-          const migratedCurrentDay = migratedDays[legacyCurrentDay] ? legacyCurrentDay : Object.keys(migratedDays)[0] || INITIAL_DAY_ID;
-          profilesList = [{ id: migratedId, name: migratedName }];
-          const migratedProfile = legacyProfile ? sanitizeProfile({ ...DEFAULT_PROFILE, ...legacyProfile }) : DEFAULT_PROFILE;
-          saveState(makeProfileKey(migratedId, 'profile'), migratedProfile);
-          saveState(makeProfileKey(migratedId, 'slots'), migratedSlots);
-          saveState(makeProfileKey(migratedId, 'days'), migratedDays);
-          saveState(makeProfileKey(migratedId, 'current_day'), migratedCurrentDay);
-          removeState(PROFILE_STORAGE_KEY);
-          removeState(LEGACY_PROFILE_STORAGE_KEY);
-        }
-
-        if (profilesList.length === 0) {
-          const defaultId = generateProfileId();
-          profilesList = [{ id: defaultId, name: 'Perfil Principal' }];
-          const defaultDays = { [INITIAL_DAY_ID]: getInitialDayState(INITIAL_SLOT_KEYS) };
-          saveState(makeProfileKey(defaultId, 'profile'), DEFAULT_PROFILE);
-          saveState(makeProfileKey(defaultId, 'slots'), INITIAL_SLOT_KEYS);
-          saveState(makeProfileKey(defaultId, 'days'), defaultDays);
-          saveState(makeProfileKey(defaultId, 'current_day'), INITIAL_DAY_ID);
-        }
-
-        let selectedId = loadState(SELECTED_PROFILE_ID_KEY, profilesList[0]?.id || null);
-        if (!profilesList.some(p=>p.id===selectedId)) selectedId = profilesList[0]?.id || null;
-
-        saveState(PROFILES_INDEX_KEY, profilesList);
-        if (selectedId) saveState(SELECTED_PROFILE_ID_KEY, selectedId);
-
-        if (cancelled) return;
-        setProfiles(profilesList);
-        setSelectedProfileId(selectedId);
-
-        if (selectedId) {
-          const bundle = loadProfileBundle(selectedId);
-          if (cancelled) return;
-          setProfile(bundle.profile);
-          setSlotKeys(bundle.slotKeys);
-          setAllDays(bundle.allDays);
-          setCurrentDayId(bundle.currentDayId);
-          const activeMeta = profilesList.find(p=>p.id===selectedId);
-          setProfileNameDraft(activeMeta ? activeMeta.name : '');
-        } else {
-          fallbackBootstrap();
-        }
-      } catch (error) {
-        console.error('Falha ao carregar dados locais, aplicando padrão', error);
-        if (!cancelled) fallbackBootstrap();
-      } finally {
-        if (!cancelled) {
-          setIsInitialized(true);
-          setIsProfileHydrating(false);
-        }
-      }
-    };
-
-    bootstrap();
-
-    return () => { cancelled = true; };
-  },[]);
-
-  useEffect(()=>{
-    if (!isInitialized || !selectedProfileId) return;
+    if (!selectedProfileId) return;
     setIsProfileHydrating(true);
     const bundle = loadProfileBundle(selectedProfileId);
     setProfile(bundle.profile);
@@ -402,43 +382,42 @@ function App(){
     const activeMeta = profiles.find(p=>p.id===selectedProfileId);
     setProfileNameDraft(activeMeta ? activeMeta.name : '');
     setIsProfileHydrating(false);
-  },[selectedProfileId, isInitialized]);
+  },[selectedProfileId, profiles]);
 
   useEffect(()=>{
-    if (!isInitialized) return;
     const activeMeta = profiles.find(p=>p.id===selectedProfileId);
     setProfileNameDraft(activeMeta ? activeMeta.name : '');
-  },[profiles, selectedProfileId, isInitialized]);
+  },[profiles, selectedProfileId]);
 
   useEffect(()=>{
-    if (!isInitialized) return;
+    if (profiles.length === 0) return;
     saveState(PROFILES_INDEX_KEY, profiles);
-  },[profiles, isInitialized]);
+  },[profiles]);
 
   useEffect(()=>{
-    if (!isInitialized || !selectedProfileId) return;
+    if (!selectedProfileId) return;
     saveState(SELECTED_PROFILE_ID_KEY, selectedProfileId);
-  },[selectedProfileId, isInitialized]);
+  },[selectedProfileId]);
 
   useEffect(()=>{
-    if (!isInitialized || !selectedProfileId || isProfileHydrating) return;
+    if (!selectedProfileId || isProfileHydrating) return;
     saveState(makeProfileKey(selectedProfileId, 'profile'), profile);
-  },[profile, selectedProfileId, isInitialized, isProfileHydrating]);
+  },[profile, selectedProfileId, isProfileHydrating]);
 
   useEffect(()=>{
-    if (!isInitialized || !selectedProfileId || isProfileHydrating) return;
+    if (!selectedProfileId || isProfileHydrating) return;
     saveState(makeProfileKey(selectedProfileId, 'days'), allDays);
-  },[allDays, selectedProfileId, isInitialized, isProfileHydrating]);
+  },[allDays, selectedProfileId, isProfileHydrating]);
 
   useEffect(()=>{
-    if (!isInitialized || !selectedProfileId || isProfileHydrating) return;
+    if (!selectedProfileId || isProfileHydrating) return;
     saveState(makeProfileKey(selectedProfileId, 'current_day'), currentDayId);
-  },[currentDayId, selectedProfileId, isInitialized, isProfileHydrating]);
+  },[currentDayId, selectedProfileId, isProfileHydrating]);
 
   useEffect(()=>{
-    if (!isInitialized || !selectedProfileId || isProfileHydrating) return;
+    if (!selectedProfileId || isProfileHydrating) return;
     saveState(makeProfileKey(selectedProfileId, 'slots'), slotKeys);
-  },[slotKeys, selectedProfileId, isInitialized, isProfileHydrating]);
+  },[slotKeys, selectedProfileId, isProfileHydrating]);
 
   /* UI */
   const [isProfileMinimized, setIsProfileMinimized] = useState(false);
@@ -620,17 +599,6 @@ function App(){
       return acc;
     },{kcal:0,protein:0,carbs:0,fats:0});
   },[day]);
-
-  if (!isInitialized) {
-    return (
-      <div className="min-h-screen bg-[#0a0a1a] text-slate-200 font-inter flex items-center justify-center">
-        <div className="text-center space-y-2">
-          <h1 className="text-xl font-semibold text-white">Carregando seus dados locais...</h1>
-          <p className="text-sm text-slate-400">Aguarde enquanto verificamos perfis e refeições salvas neste dispositivo.</p>
-        </div>
-      </div>
-    );
-  }
 
   const getSlotLabel = (key)=>{ const i = slotKeys.indexOf(key); return i===-1 ? key : `Refeição ${i+1}`; };
   const updateDay = (newDay)=> setAllDays(prev=>({ ...prev, [currentDayId]: newDay }));

--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>Cardápio Inteligente — MVP v5.7</title>
+  <title>Cardápio Inteligente — MVP v5.6</title>
 
   <!-- Tailwind -->
   <script src="https://cdn.tailwindcss.com"></script>
@@ -26,17 +26,10 @@
 
   <script type="text/babel">
 /* === Estado/Utilidades === */
-const PROFILE_STORAGE_KEY = 'dietacardapio_profile_v1';
-const LEGACY_PROFILE_STORAGE_KEY = "cardapio_profile_v5_3";
-const LEGACY_ALL_DAYS_STORAGE_KEY = "cardapio_all_days_v5_6";
-const LEGACY_SLOTS_STORAGE_KEY = "cardapio_slotkeys_v5_6";
-const LEGACY_CURRENT_DAY_ID_STORAGE_KEY = "cardapio_current_day_id_v5_6";
-
-const STORAGE_NAMESPACE = "cardapio_v6";
-const PROFILES_INDEX_KEY = `${STORAGE_NAMESPACE}_profiles_index`;
-const SELECTED_PROFILE_ID_KEY = `${STORAGE_NAMESPACE}_selected_profile_id`;
-const makeProfileKey = (profileId, segment) => `${STORAGE_NAMESPACE}_${segment}_${profileId}`;
-
+const PROFILE_STORAGE_KEY = "cardapio_profile_v5_3";
+const ALL_DAYS_STORAGE_KEY = "cardapio_all_days_v5_6";
+const SLOTS_STORAGE_KEY = "cardapio_slotkeys_v5_6";
+const CURRENT_DAY_ID_STORAGE_KEY = "cardapio_current_day_id_v5_6";
 const INITIAL_DAY_ID = 'day-1';
 
 const INPUT_RANGES = {
@@ -59,34 +52,25 @@ function normalizeAndValidateInput(key, value) {
   return numericValue;
 }
 
-const STATIC_BASE_URL = (() => {
-  try {
-    const { origin, pathname } = window.location;
-    if (pathname.endsWith('/')) return `${origin}${pathname}`;
-    if (pathname.includes('.')) {
-      return `${origin}${pathname.slice(0, pathname.lastIndexOf('/') + 1)}`;
-    }
-    return `${origin}${pathname}/`;
-  } catch (error) {
-    console.warn('Não foi possível determinar a base estática', error);
-    return window.location ? window.location.href : '';
-  }
-})();
-
-const resolveStaticAsset = (relativePath) => {
-  try {
-    return new URL(relativePath, STATIC_BASE_URL).toString();
-  } catch (e) {
-    console.warn("Falha ao resolver caminho estático", relativePath, e);
-    return relativePath;
-  }
-};
-
 const loadState = (key, defaultState) => {
   try {
     const raw = localStorage.getItem(key);
     if (raw === null || raw === "undefined") return defaultState;
     const state = JSON.parse(raw);
+
+    if (key === PROFILE_STORAGE_KEY) {
+      const validated = { ...state };
+      let reset = false;
+      Object.keys(INPUT_RANGES).forEach(k => {
+        const r = INPUT_RANGES[k];
+        const v = Number(state[k]);
+        if (Number.isNaN(v) || v < r.min || v > r.max) { validated[k] = DEFAULT_PROFILE[k]; reset = true; }
+      });
+      if (!['M','F'].includes(state.sex)) { validated.sex = DEFAULT_PROFILE.sex; reset = true; }
+      if (!['loss','maintain','gain','recomp'].includes(state.goal)) { validated.goal = DEFAULT_PROFILE.goal; reset = true; }
+      if (reset) console.warn("Perfil: valores inválidos restaurados.");
+      return validated;
+    }
     return state;
   } catch(e){ console.error("loadState", key, e); return defaultState; }
 };
@@ -94,20 +78,6 @@ const loadState = (key, defaultState) => {
 const saveState = (key, state) => {
   try { localStorage.setItem(key, JSON.stringify(state)); }
   catch(e){ console.error("saveState", key, e); }
-};
-
-const removeState = (key) => {
-  try { localStorage.removeItem(key); }
-  catch(e){ console.error("removeState", key, e); }
-};
-
-const generateProfileId = () => {
-  try {
-    if (window.crypto && window.crypto.randomUUID) return window.crypto.randomUUID();
-  } catch (e) {
-    console.warn("randomUUID indisponível", e);
-  }
-  return `profile-${Math.random().toString(36).slice(2,10)}-${Date.now()}`;
 };
 
 /* === Cálculos === */
@@ -158,7 +128,7 @@ function calculateMealMacros(entry){
 }
 
 /* === Dados de refeições (mesmos do seu app) === */
-const DEFAULT_MEALS = [
+const MEALS = [
   { id:"whey_agua", name:"Whey Protein Isolado (Água)", block:"250", tags:["High Protein","Low Carb","Quick"], ingredients:[{ name:"Whey Protein (1 Scoop)", protein:25, carbs:5, fats:4, baseKcal:155 }] },
   { id:"shake_caseina", name:"Shake de Caseína (Pré-Cama)", block:"250", tags:["High Protein","Low Carb"], ingredients:[{ name:"Caseína/Whey", protein:30, carbs:4, fats:3, baseKcal:170 }] },
   { id:"ovo_cozido", name:"2 Ovos Cozidos", block:"250", tags:["High Protein","Low Carb","High Fat"], ingredients:[{ name:"Ovo Cozido (2 unid.)", protein:12, carbs:1, fats:10, baseKcal:140 }] },
@@ -174,13 +144,14 @@ const DEFAULT_MEALS = [
   { id:"massa_pesto_frango_azeitonas", name:"Massa Integral c/ Pesto, Frango e Azeitonas", block:"750", tags:["High Carb","High Protein","Post-Workout"], ingredients:[{ name:"Massa Integral Cozida (150g)", protein:7, carbs:45, fats:2, baseKcal:230 }, { name:"Peito de Frango Picado (150g)", protein:40, carbs:0, fats:6, baseKcal:226 }, { name:"Molho Pesto (2 col. sopa)", protein:5, carbs:5, fats:20, baseKcal:220 }, { name:"Tomate Seco e Azeitonas", protein:0, carbs:5, fats:6, baseKcal:70 }] },
 ];
 
-const addTotalsToMeals = (mealsList) => mealsList.map(meal => {
+const MEALS_WITH_TOTALS = MEALS.map(meal => {
   const totals = meal.ingredients.reduce((acc, ing) => {
     const m = calculateMealMacros({ ...ing, portion: 1 });
     acc.protein+=m.protein; acc.carbs+=m.carbs; acc.fats+=m.fats; acc.kcal+=m.kcal; return acc;
   }, { protein:0, carbs:0, fats:0, kcal:0 });
   return { ...meal, ...totals };
 });
+const TAGS = ["High Protein","Low Carb","High Carb","Plant-Based","Balanced","High Fat Saudável","Low Protein","High Fat","Post-Workout","Quick","Bulk","BR"];
 const PORTION_OPTIONS = [0.5, 1, 1.5, 2];
 
 const MinimizeButton = ({ isMinimized, toggleMinimize }) => (
@@ -220,204 +191,31 @@ function Section({ title, children, right, isMinimized }) {
 }
 
 const DEFAULT_PROFILE = { sex:"M", age:33, weight:73, height:170, activity:"moderate", goal:"recomp", neck:36, waist:85, hip:95, photoUrl:'https://placehold.co/100x100/1E293B/E2E8F0?text=Foto' };
-
-function sanitizeProfile(rawProfile) {
-  const candidate = { ...DEFAULT_PROFILE, ...(rawProfile || {}) };
-  const validated = { ...candidate };
-  let reset = false;
-
-  Object.keys(INPUT_RANGES).forEach(k => {
-    const range = INPUT_RANGES[k];
-    const value = Number(candidate[k]);
-    if (Number.isNaN(value) || value < range.min || value > range.max) {
-      validated[k] = DEFAULT_PROFILE[k];
-      reset = true;
-    }
-  });
-
-  if (!['M','F'].includes(candidate.sex)) { validated.sex = DEFAULT_PROFILE.sex; reset = true; }
-  if (!['loss','maintain','gain','recomp'].includes(candidate.goal)) { validated.goal = DEFAULT_PROFILE.goal; reset = true; }
-
-  if (reset) console.warn("Perfil: valores inválidos restaurados.");
-  return validated;
-}
 const INITIAL_SLOT_KEYS = [`slot-1`,`slot-2`,`slot-3`,`slot-4`];
 const getInitialDayState = (keys) => keys.reduce((acc,k)=>({ ...acc, [k]:[] }),{});
-const normalizeDays = (days, slotKeys) => {
-  const base = days && typeof days === 'object' ? days : {};
-  const normalized = {};
-  const validSlots = Array.isArray(slotKeys) && slotKeys.length>0 ? slotKeys : INITIAL_SLOT_KEYS;
-  const dayIds = Object.keys(base).length>0 ? Object.keys(base) : [INITIAL_DAY_ID];
-  dayIds.forEach(id => {
-    const dayData = base[id] && typeof base[id] === 'object' ? base[id] : {};
-    normalized[id] = validSlots.reduce((acc, slot)=>({ ...acc, [slot]: Array.isArray(dayData[slot]) ? dayData[slot] : [] }), {});
-  });
-  return normalized;
-};
-const loadProfileBundle = (profileId) => {
-  const storedProfile = sanitizeProfile(loadState(makeProfileKey(profileId, 'profile'), DEFAULT_PROFILE));
-  const storedSlots = loadState(makeProfileKey(profileId, 'slots'), INITIAL_SLOT_KEYS);
-  const slotKeys = Array.isArray(storedSlots) && storedSlots.length>0 ? storedSlots : INITIAL_SLOT_KEYS;
-  const storedDays = loadState(makeProfileKey(profileId, 'days'), { [INITIAL_DAY_ID]: getInitialDayState(slotKeys) });
-  const normalizedDays = normalizeDays(storedDays, slotKeys);
-  const storedCurrentDay = loadState(makeProfileKey(profileId, 'current_day'), Object.keys(normalizedDays)[0] || INITIAL_DAY_ID);
-  const currentDayId = normalizedDays[storedCurrentDay] ? storedCurrentDay : Object.keys(normalizedDays)[0] || INITIAL_DAY_ID;
-  return {
-    profile: storedProfile,
-    slotKeys,
-    allDays: normalizedDays,
-    currentDayId,
-  };
-};
-
-function bootstrapProfilesFromStorage() {
-  let profilesList = [];
-  const storedProfiles = loadState(PROFILES_INDEX_KEY, null);
-  if (Array.isArray(storedProfiles)) {
-    profilesList = storedProfiles.filter(p => p && p.id && p.name);
-  }
-
-  if (profilesList.length === 0) {
-    const singleProfile = loadState(PROFILE_STORAGE_KEY, null);
-    const legacyProfile = singleProfile || loadState(LEGACY_PROFILE_STORAGE_KEY, null);
-    const legacySlots = loadState(LEGACY_SLOTS_STORAGE_KEY, null);
-    const legacyDays = loadState(LEGACY_ALL_DAYS_STORAGE_KEY, null);
-    const legacyCurrentDay = loadState(LEGACY_CURRENT_DAY_ID_STORAGE_KEY, null);
-
-    if (legacyProfile || legacySlots || legacyDays) {
-      const migratedId = generateProfileId();
-      const migratedName = legacyProfile && typeof legacyProfile.name === 'string' && legacyProfile.name.trim().length>0
-        ? legacyProfile.name.trim()
-        : 'Perfil Principal';
-      const migratedSlots = Array.isArray(legacySlots) && legacySlots.length>0 ? legacySlots : INITIAL_SLOT_KEYS;
-      const migratedDays = normalizeDays(legacyDays, migratedSlots);
-      const migratedCurrentDay = migratedDays[legacyCurrentDay] ? legacyCurrentDay : Object.keys(migratedDays)[0] || INITIAL_DAY_ID;
-      const migratedProfile = legacyProfile ? sanitizeProfile({ ...DEFAULT_PROFILE, ...legacyProfile }) : DEFAULT_PROFILE;
-
-      profilesList = [{ id: migratedId, name: migratedName }];
-      saveState(makeProfileKey(migratedId, 'profile'), migratedProfile);
-      saveState(makeProfileKey(migratedId, 'slots'), migratedSlots);
-      saveState(makeProfileKey(migratedId, 'days'), migratedDays);
-      saveState(makeProfileKey(migratedId, 'current_day'), migratedCurrentDay);
-      removeState(PROFILE_STORAGE_KEY);
-      removeState(LEGACY_PROFILE_STORAGE_KEY);
-      removeState(LEGACY_SLOTS_STORAGE_KEY);
-      removeState(LEGACY_ALL_DAYS_STORAGE_KEY);
-      removeState(LEGACY_CURRENT_DAY_ID_STORAGE_KEY);
-    }
-  }
-
-  if (profilesList.length === 0) {
-    const defaultId = generateProfileId();
-    profilesList = [{ id: defaultId, name: 'Perfil Principal' }];
-    const defaultDays = { [INITIAL_DAY_ID]: getInitialDayState(INITIAL_SLOT_KEYS) };
-    saveState(makeProfileKey(defaultId, 'profile'), DEFAULT_PROFILE);
-    saveState(makeProfileKey(defaultId, 'slots'), INITIAL_SLOT_KEYS);
-    saveState(makeProfileKey(defaultId, 'days'), defaultDays);
-    saveState(makeProfileKey(defaultId, 'current_day'), INITIAL_DAY_ID);
-  }
-
-  let selectedId = loadState(SELECTED_PROFILE_ID_KEY, profilesList[0]?.id || null);
-  if (!profilesList.some(p => p.id === selectedId)) {
-    selectedId = profilesList[0]?.id || null;
-  }
-  if (selectedId) {
-    saveState(SELECTED_PROFILE_ID_KEY, selectedId);
-  }
-  saveState(PROFILES_INDEX_KEY, profilesList);
-
-  const bundle = selectedId
-    ? loadProfileBundle(selectedId)
-    : {
-        profile: DEFAULT_PROFILE,
-        slotKeys: INITIAL_SLOT_KEYS,
-        allDays: { [INITIAL_DAY_ID]: getInitialDayState(INITIAL_SLOT_KEYS) },
-        currentDayId: INITIAL_DAY_ID,
-      };
-
-  return {
-    profilesList,
-    selectedId,
-    profile: bundle.profile,
-    slotKeys: bundle.slotKeys,
-    allDays: bundle.allDays,
-    currentDayId: bundle.currentDayId,
-  };
-}
 
 function App(){
-  const { useMemo, useState, useEffect, useRef } = React;
-
-  const bootstrapRef = useRef(null);
-  if (!bootstrapRef.current) {
-    bootstrapRef.current = bootstrapProfilesFromStorage();
-  }
-  const initialData = bootstrapRef.current;
+  const { useMemo, useState, useEffect } = React;
 
   /* Estado + persistência */
-  const [profiles, setProfiles] = useState(initialData.profilesList);
-  const [selectedProfileId, setSelectedProfileId] = useState(initialData.selectedId);
-  const [profile, setProfile] = useState(initialData.profile);
+  const [profile, setProfile] = useState(()=>loadState(PROFILE_STORAGE_KEY, DEFAULT_PROFILE));
   const [isProfileLocked, setIsProfileLocked] = useState(false);
-  const [slotKeys, setSlotKeys] = useState(initialData.slotKeys);
-  const [currentDayId, setCurrentDayId] = useState(initialData.currentDayId);
-  const [allDays, setAllDays] = useState(initialData.allDays);
-  const [isProfileHydrating, setIsProfileHydrating] = useState(false);
-  const [profileNameDraft, setProfileNameDraft] = useState(() => {
-    const activeMeta = initialData.profilesList.find(p => p.id === initialData.selectedId);
-    return activeMeta ? activeMeta.name : '';
+  const [slotKeys, setSlotKeys] = useState(()=> {
+    const k = loadState(SLOTS_STORAGE_KEY, INITIAL_SLOT_KEYS);
+    return Array.isArray(k) && k.length>0 ? k : INITIAL_SLOT_KEYS;
   });
-  const [isAddingProfile, setIsAddingProfile] = useState(false);
-  const [newProfileName, setNewProfileName] = useState('');
+  const [currentDayId, setCurrentDayId] = useState(()=>loadState(CURRENT_DAY_ID_STORAGE_KEY, INITIAL_DAY_ID));
+  const [allDays, setAllDays] = useState(()=> {
+    const d = loadState(ALL_DAYS_STORAGE_KEY, {});
+    if (Object.keys(d).length===0 || !d[INITIAL_DAY_ID]) return { [INITIAL_DAY_ID]: getInitialDayState(INITIAL_SLOT_KEYS) };
+    return d;
+  });
   const day = allDays[currentDayId] || getInitialDayState(slotKeys);
 
-  useEffect(()=>{
-    if (!selectedProfileId) return;
-    setIsProfileHydrating(true);
-    const bundle = loadProfileBundle(selectedProfileId);
-    setProfile(bundle.profile);
-    setSlotKeys(bundle.slotKeys);
-    setAllDays(bundle.allDays);
-    setCurrentDayId(bundle.currentDayId);
-    const activeMeta = profiles.find(p=>p.id===selectedProfileId);
-    setProfileNameDraft(activeMeta ? activeMeta.name : '');
-    setIsProfileHydrating(false);
-  },[selectedProfileId, profiles]);
-
-  useEffect(()=>{
-    const activeMeta = profiles.find(p=>p.id===selectedProfileId);
-    setProfileNameDraft(activeMeta ? activeMeta.name : '');
-  },[profiles, selectedProfileId]);
-
-  useEffect(()=>{
-    if (profiles.length === 0) return;
-    saveState(PROFILES_INDEX_KEY, profiles);
-  },[profiles]);
-
-  useEffect(()=>{
-    if (!selectedProfileId) return;
-    saveState(SELECTED_PROFILE_ID_KEY, selectedProfileId);
-  },[selectedProfileId]);
-
-  useEffect(()=>{
-    if (!selectedProfileId || isProfileHydrating) return;
-    saveState(makeProfileKey(selectedProfileId, 'profile'), profile);
-  },[profile, selectedProfileId, isProfileHydrating]);
-
-  useEffect(()=>{
-    if (!selectedProfileId || isProfileHydrating) return;
-    saveState(makeProfileKey(selectedProfileId, 'days'), allDays);
-  },[allDays, selectedProfileId, isProfileHydrating]);
-
-  useEffect(()=>{
-    if (!selectedProfileId || isProfileHydrating) return;
-    saveState(makeProfileKey(selectedProfileId, 'current_day'), currentDayId);
-  },[currentDayId, selectedProfileId, isProfileHydrating]);
-
-  useEffect(()=>{
-    if (!selectedProfileId || isProfileHydrating) return;
-    saveState(makeProfileKey(selectedProfileId, 'slots'), slotKeys);
-  },[slotKeys, selectedProfileId, isProfileHydrating]);
+  useEffect(()=>{ saveState(PROFILE_STORAGE_KEY, profile); },[profile]);
+  useEffect(()=>{ saveState(ALL_DAYS_STORAGE_KEY, allDays); },[allDays]);
+  useEffect(()=>{ saveState(CURRENT_DAY_ID_STORAGE_KEY, currentDayId); },[currentDayId]);
+  useEffect(()=>{ saveState(SLOTS_STORAGE_KEY, slotKeys); },[slotKeys]);
 
   /* UI */
   const [isProfileMinimized, setIsProfileMinimized] = useState(false);
@@ -427,80 +225,6 @@ function App(){
   const [selectedBlock, setSelectedBlock] = useState("all");
   const [activeTags, setActiveTags] = useState([]);
   const [search, setSearch] = useState("");
-  const [meals, setMeals] = useState(DEFAULT_MEALS);
-  const [isMealsLoading, setIsMealsLoading] = useState(true);
-  const [mealsError, setMealsError] = useState('');
-
-  const handleSelectProfile = (id) => {
-    if (!id || id === selectedProfileId) return;
-    setIsProfileHydrating(true);
-    setSelectedProfileId(id);
-    setIsAddingProfile(false);
-  };
-
-  const finalizeProfileName = () => {
-    if (!selectedProfileId) return;
-    const trimmed = profileNameDraft.trim();
-    const fallbackIndex = Math.max(1, profiles.findIndex(p=>p.id===selectedProfileId) + 1);
-    const finalName = trimmed.length>0 ? trimmed : `Perfil ${fallbackIndex}`;
-    setProfiles(prev=> prev.map(p=> p.id===selectedProfileId ? { ...p, name: finalName } : p));
-    setProfileNameDraft(finalName);
-  };
-
-  const handleCreateProfile = (name) => {
-    const trimmed = name.trim();
-    const finalName = trimmed.length>0 ? trimmed : `Perfil ${profiles.length+1}`;
-    const newId = generateProfileId();
-    const defaultDays = { [INITIAL_DAY_ID]: getInitialDayState(INITIAL_SLOT_KEYS) };
-    saveState(makeProfileKey(newId, 'profile'), DEFAULT_PROFILE);
-    saveState(makeProfileKey(newId, 'slots'), INITIAL_SLOT_KEYS);
-    saveState(makeProfileKey(newId, 'days'), defaultDays);
-    saveState(makeProfileKey(newId, 'current_day'), INITIAL_DAY_ID);
-    setProfiles(prev=> [...prev, { id: newId, name: finalName }]);
-    setIsProfileHydrating(true);
-    setProfile(DEFAULT_PROFILE);
-    setSlotKeys(INITIAL_SLOT_KEYS);
-    setAllDays(defaultDays);
-    setCurrentDayId(INITIAL_DAY_ID);
-    setProfileNameDraft(finalName);
-    setSelectedProfileId(newId);
-    setIsAddingProfile(false);
-    setNewProfileName('');
-  };
-
-  const handleDeleteProfile = () => {
-    if (profiles.length<=1 || !selectedProfileId) return;
-    const activeMeta = profiles.find(p=>p.id===selectedProfileId);
-    const ok = window.confirm(`Excluir o perfil "${activeMeta?.name || 'Atual'}"? Esta ação não pode ser desfeita.`);
-    if (!ok) return;
-    removeState(makeProfileKey(selectedProfileId, 'profile'));
-    removeState(makeProfileKey(selectedProfileId, 'slots'));
-    removeState(makeProfileKey(selectedProfileId, 'days'));
-    removeState(makeProfileKey(selectedProfileId, 'current_day'));
-    const remaining = profiles.filter(p=>p.id!==selectedProfileId);
-    setProfiles(remaining);
-    const nextId = remaining[0]?.id || null;
-    if (nextId) {
-      setIsProfileHydrating(true);
-      setSelectedProfileId(nextId);
-    } else {
-      const fallbackId = generateProfileId();
-      const fallbackMeta = { id: fallbackId, name: 'Perfil Principal' };
-      const fallbackDays = { [INITIAL_DAY_ID]: getInitialDayState(INITIAL_SLOT_KEYS) };
-      setProfiles([fallbackMeta]);
-      setIsProfileHydrating(true);
-      setSelectedProfileId(fallbackId);
-      setProfile(DEFAULT_PROFILE);
-      setSlotKeys(INITIAL_SLOT_KEYS);
-      setAllDays(fallbackDays);
-      setCurrentDayId(INITIAL_DAY_ID);
-      setProfileNameDraft(fallbackMeta.name);
-      saveState(makeProfileKey(fallbackId, 'profile'), DEFAULT_PROFILE);
-      saveState(makeProfileKey(fallbackId, 'slots'), INITIAL_SLOT_KEYS);
-      saveState(makeProfileKey(fallbackId, 'days'), fallbackDays);
-      saveState(makeProfileKey(fallbackId, 'current_day'), INITIAL_DAY_ID);
-    }
-  };
 
   /* <<< CORREÇÃO: edição suave + clamp no onBlur >>> */
   const handleProfileChange = (key, value) => {
@@ -525,37 +249,6 @@ function App(){
     if (file) setProfile(p => ({ ...p, photoUrl: URL.createObjectURL(file) }));
   };
 
-  useEffect(()=>{
-    let isMounted = true;
-    setIsMealsLoading(true);
-    const alimentosUrl = resolveStaticAsset('./alimentos.json');
-    fetch(alimentosUrl, { cache: 'no-store' })
-      .then(res => {
-        if (!res.ok) throw new Error(`HTTP ${res.status}`);
-        return res.json();
-      })
-      .then(data => {
-        if (!isMounted) return;
-        const parsed = Array.isArray(data) ? data : Array.isArray(data?.meals) ? data.meals : [];
-        if (parsed.length>0) {
-          setMeals(parsed);
-          setMealsError('');
-        } else {
-          setMeals(DEFAULT_MEALS);
-          setMealsError('');
-        }
-        setIsMealsLoading(false);
-      })
-      .catch(err => {
-        if (!isMounted) return;
-        console.error('Erro ao carregar alimentos externos', err);
-        setMeals(DEFAULT_MEALS);
-        setMealsError('Não foi possível carregar o cardápio externo. Usando lista padrão.');
-        setIsMealsLoading(false);
-      });
-    return () => { isMounted = false; };
-  },[]);
-
   /* Cálculos memoizados */
   const bmr = useMemo(()=>calcBMR(profile),[profile]);
   const tdee = useMemo(()=>calcTDEE(bmr, profile.activity),[bmr, profile.activity]);
@@ -563,40 +256,21 @@ function App(){
   const macroTargets = useMemo(()=>deriveMacroTargets({ weight: Number(profile.weight)||0, calories: targetCalories }),[profile.weight, targetCalories]);
   const bodyFat = useMemo(()=>{ const v = calcBF({ ...profile, height:Number(profile.height)||0, neck:Number(profile.neck)||0, waist:Number(profile.waist)||0, hip:Number(profile.hip)||0 }); return v!=null ? round(v,1) : null; },[profile.sex, profile.height, profile.neck, profile.waist, profile.hip]);
 
-  const mealsWithTotals = useMemo(()=> addTotalsToMeals(meals && meals.length>0 ? meals : DEFAULT_MEALS),[meals]);
-  const availableTags = useMemo(()=> {
-    const tags = new Set();
-    mealsWithTotals.forEach(meal => {
-      (meal.tags || []).forEach(tag => tags.add(tag));
-    });
-    return Array.from(tags).sort((a,b)=>a.localeCompare(b));
-  },[mealsWithTotals]);
-
-  const filteredMeals = useMemo(()=> mealsWithTotals.filter(m=>{
-    const tags = Array.isArray(m.tags) ? m.tags : [];
+  const filteredMeals = useMemo(()=> MEALS_WITH_TOTALS.filter(m=>{
     const blockOk = selectedBlock==="all" || m.block===selectedBlock;
-    const tagOk = activeTags.length===0 || activeTags.every(t=>tags.includes(t));
-    const query = search.trim().toLowerCase();
-    const searchOk = query.length===0 || m.name.toLowerCase().includes(query);
+    const tagOk = activeTags.length===0 || activeTags.every(t=>m.tags.includes(t));
+    const searchOk = m.name.toLowerCase().includes(search.toLowerCase());
     return blockOk && tagOk && searchOk;
-  }),[selectedBlock, activeTags, search, mealsWithTotals]);
+  }),[selectedBlock, activeTags, search]);
 
   const totals = useMemo(()=>{
-    const all = Object.values(day || {}).flat();
+    const all = Object.values(day).flat();
     return all.reduce((acc, mealEntry)=>{
-      const mealTotals = Array.isArray(mealEntry?.ingredients) ? mealEntry.ingredients.reduce((inner, ing)=>{
-        const macros = calculateMealMacros({ ...ing, portion: ing.portion ?? 1 });
-        inner.kcal += macros.kcal;
-        inner.protein += macros.protein;
-        inner.carbs += macros.carbs;
-        inner.fats += macros.fats;
-        return inner;
-      },{kcal:0,protein:0,carbs:0,fats:0}) : { kcal:0,protein:0,carbs:0,fats:0 };
-      acc.kcal += mealTotals.kcal;
-      acc.protein += mealTotals.protein;
-      acc.carbs += mealTotals.carbs;
-      acc.fats += mealTotals.fats;
-      return acc;
+      const mealTotals = mealEntry.ingredients.reduce((a, ing)=>{
+        const m = calculateMealMacros(ing);
+        a.kcal+=m.kcal; a.protein+=m.protein; a.carbs+=m.carbs; a.fats+=m.fats; return a;
+      },{kcal:0,protein:0,carbs:0,fats:0});
+      acc.kcal+=mealTotals.kcal; acc.protein+=mealTotals.protein; acc.carbs+=mealTotals.carbs; acc.fats+=mealTotals.fats; return acc;
     },{kcal:0,protein:0,carbs:0,fats:0});
   },[day]);
 
@@ -686,7 +360,7 @@ function App(){
         <div className="max-w-7xl mx-auto flex items-center justify-between">
           <div>
             <h1 className="text-2xl font-bold tracking-tight text-white">Cardápio Inteligente</h1>
-            <p className="text-sm text-slate-400">Monte seu dia com porções ajustáveis e metas calculadas (v5.7)</p>
+            <p className="text-sm text-slate-400">Monte seu dia com porções ajustáveis e metas calculadas (v5.6)</p>
           </div>
           <div className="hidden md:flex items-center gap-3">
             <a href="#biblioteca" className="text-sm px-3 py-1 rounded border border-slate-600 hover:bg-slate-700/40 transition">Biblioteca</a>
@@ -711,40 +385,6 @@ function App(){
             </div>
 
             <div className="mt-4">
-              <div className="mb-5 space-y-4">
-                <div>
-                  <label className="text-xs uppercase tracking-wide text-slate-400 block mb-2">Perfil ativo neste dispositivo</label>
-                  <div className="flex flex-col sm:flex-row sm:items-center gap-2">
-                    <select value={selectedProfileId || ''} onChange={(e)=>handleSelectProfile(e.target.value)} className="bg-slate-900 border border-slate-600 rounded px-3 py-2 text-sm focus:ring-emerald-500 focus:border-emerald-500">
-                      {profiles.map(meta=> (<option key={meta.id} value={meta.id}>{meta.name}</option>))}
-                    </select>
-                    <div className="flex gap-2">
-                      <button onClick={()=>{ setIsAddingProfile(true); setNewProfileName(''); }} disabled={isAddingProfile} className={`text-xs px-3 py-2 rounded border transition focus:outline-none focus:ring-1 focus:ring-emerald-500 ${isAddingProfile ? 'border-slate-700 text-slate-500 cursor-not-allowed' : 'border-emerald-500 text-emerald-300 hover:bg-emerald-500/10'}`}>+ Novo</button>
-                      <button onClick={handleDeleteProfile} disabled={profiles.length<=1} className={`text-xs px-3 py-2 rounded border transition focus:outline-none focus:ring-1 focus:ring-red-500 ${profiles.length<=1 ? 'border-slate-700 text-slate-500 cursor-not-allowed' : 'border-red-500 text-red-300 hover:bg-red-500/10'}`}>Excluir</button>
-                    </div>
-                  </div>
-                </div>
-
-                <div>
-                  <label className="text-xs text-slate-400 block mb-1">Nome do perfil</label>
-                  <input value={profileNameDraft} onChange={(e)=>setProfileNameDraft(e.target.value)} onBlur={finalizeProfileName} onKeyDown={(e)=>{ if (e.key==='Enter'){ e.preventDefault(); finalizeProfileName(); e.currentTarget.blur(); } }} className="w-full bg-slate-900 border border-slate-600 rounded px-3 py-2 text-sm focus:ring-emerald-500 focus:border-emerald-500" placeholder="Ex.: Leo, Jaque, Bulking" />
-                  <p className="text-[11px] text-slate-500 mt-1">Cada perfil guarda metas, refeições e slots de forma independente.</p>
-                </div>
-
-                {isAddingProfile && (
-                  <form onSubmit={(e)=>{ e.preventDefault(); handleCreateProfile(newProfileName); }} className="bg-slate-900/60 border border-slate-700 rounded-xl p-3 flex flex-col sm:flex-row sm:items-center gap-3">
-                    <input value={newProfileName} onChange={(e)=>setNewProfileName(e.target.value)} className="flex-1 bg-slate-950 border border-slate-700 rounded px-3 py-2 text-sm focus:ring-emerald-500 focus:border-emerald-500" placeholder="Nome do novo perfil" autoFocus />
-                    <div className="flex gap-2">
-                      <button type="submit" className="text-xs px-3 py-2 rounded border border-emerald-500 text-emerald-300 hover:bg-emerald-500/10 transition focus:outline-none focus:ring-1 focus:ring-emerald-500">Salvar</button>
-                      <button type="button" onClick={()=>{ setIsAddingProfile(false); setNewProfileName(''); }} className="text-xs px-3 py-2 rounded border border-slate-600 text-slate-400 hover:bg-slate-800/60 transition focus:outline-none focus:ring-1 focus:ring-slate-500">Cancelar</button>
-                    </div>
-                  </form>
-                )}
-
-                {isProfileHydrating && (
-                  <p className="text-xs text-slate-400">Carregando dados do perfil selecionado...</p>
-                )}
-              </div>
               <ProfilePhotoUploader photoUrl={profile.photoUrl} handleUpload={handlePhotoUpload} isDisabled={isProfileLocked}/>
               {!isProfileMinimized && (
                 <div className={`${isProfileLocked ? 'opacity-70 cursor-not-allowed':''}`} title={isProfileLocked ? "Perfil trancado" : undefined}>
@@ -879,7 +519,7 @@ function App(){
             }
           >
             <div className="flex flex-wrap mb-3">
-              {availableTags.map(t=>(
+              {TAGS.map(t=>(
                 <Pill key={t} active={activeTags.includes(t)} onClick={()=>setActiveTags(prev=> prev.includes(t) ? prev.filter(x=>x!==t) : [...prev,t])}>{t}</Pill>
               ))}
               {activeTags.length>0 && (
@@ -888,9 +528,6 @@ function App(){
             </div>
 
             <div id="biblioteca" className="grid md:grid-cols-2 gap-4 max-h-[500px] overflow-y-auto pr-2">
-              {isMealsLoading && (
-                <div className="text-slate-400 text-sm md:col-span-2 p-4 border border-dashed border-slate-700 rounded-xl text-center">Carregando cardápio atualizado...</div>
-              )}
               {filteredMeals.map(m=>(
                 <div key={m.id} className="rounded-xl border border-slate-700 bg-slate-900 p-4 transition-shadow hover:shadow-emerald-500/10 hover:shadow-xl">
                   <div className="flex items-start justify-between">
@@ -910,11 +547,10 @@ function App(){
                   </div>
                 </div>
               ))}
-              {!isMealsLoading && filteredMeals.length===0 && (
+              {filteredMeals.length===0 && (
                 <div className="text-slate-400 text-sm md:col-span-2 p-4 border border-dashed border-slate-700 rounded-xl text-center">Nenhuma refeição encontrada. Limpe os filtros.</div>
               )}
             </div>
-            {mealsError && <p className="text-xs text-amber-300 mt-2">{mealsError}</p>}
           </Section>
 
           {/* Meu Dia */}
@@ -1001,7 +637,7 @@ function App(){
       </main>
 
       <footer className="max-w-7xl mx-auto px-6 py-10 text-center text-xs text-slate-500">
-        MVP visual v5.7. Perfis locais independentes + cardápio carregado via JSON.
+        MVP visual v5.6. Planejamento multi-dia + duplicação de planos.
       </footer>
     </div>
   );


### PR DESCRIPTION
## Summary
- ensure memoized calculations run before the initialization guard so React hooks keep a stable order
- harden menu filtering and totals aggregation against missing data while showing the loading screen only after memo setup

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e423dae1a483299fc46110d7d0f8b2